### PR TITLE
Update to the latest API changes

### DIFF
--- a/.github/workflows/markdown_link_check.yml
+++ b/.github/workflows/markdown_link_check.yml
@@ -1,0 +1,12 @@
+name: Check Markdown links
+
+on: push
+
+jobs:
+  markdown-link-check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - uses: gaurav-nelson/github-action-markdown-link-check@v1
+      with:
+        use-quiet-mode: yes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,18 @@
+#Changelog 
+
+##v1.16 -> v1.2.0:
+
+- startTime argument in PATCH /transitions/:id/executions/:id can be supplied as datetime object.
+- PATCH /workflows/:id/executions/:id
+- GET /workflows/:id/executions/:id
+- DELETE /assets/:id
+- DELETE /secrets/:id
+- Update POST /workflows to include completedConfig, and support manualRetry in errorConfig
+- Update PATCH /transitions/:id to include assets, environment, environmentSecrets
+- Update PATCH /workflows/:id to include completedConfig, and errorConfig
+- POST /appClients
+- GET /appClients
+- DELETE /appClients/:id
+- GET /logs
+- DELETE /batches/:id
+- DELETE /documents:id?batchId=...

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,17 +2,17 @@
 
 ## v1.16 -> v1.2.0:
 
-- startTime argument in PATCH /transitions/:id/executions/:id can be supplied as datetime object.
-- PATCH /workflows/:id/executions/:id
-- GET /workflows/:id/executions/:id
-- DELETE /assets/:id
-- DELETE /secrets/:id
-- Update POST /workflows to include completedConfig, and support manualRetry in errorConfig
-- Update PATCH /transitions/:id to include assets, environment, environmentSecrets
-- Update PATCH /workflows/:id to include completedConfig, and errorConfig
-- POST /appClients
-- GET /appClients
-- DELETE /appClients/:id
-- GET /logs
-- DELETE /batches/:id
-- DELETE /documents:id?batchId=...
+- Updated startTime argument in UpdateTransitionExecution (PATCH /transitions/:id/executions/:id) to be a datetime object and not a string.
+- Added UpdateWorkflowExecution (PATCH /workflows/:id/executions/:id)
+- Added GetWorkflowExecution (GET /workflows/:id/executions/:id)
+- Added DeleteAsset (DELETE /assets/:id)
+- Added DeleteSecret (DELETE /secrets/:id)
+- Updated CreateWorkflow (POST /workflows) to include completedConfig, and support manualRetry in errorConfig
+- Updated UpdateTransition (PATCH /transitions/:id) to include assets, environment, environmentSecrets
+- Updated UpdateWorkflow (PATCH /workflows/:id) to include completedConfig, and errorConfig
+- Added CreateAppClient (POST /appClients)
+- Added GetAppClient (GET /appClients)
+- Added DeleteAppClient (DELETE /appClients/:id)
+- Added ListLogs (GET /logs)
+- Added DeleteBatches (DELETE /batches/:id)
+- Updated DeleteDocuments (DELETE /documents:id) to support queryparameter batchId

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog 
 
-## v1.16 -> v1.2.0:
+## Version 1.2.0 - 2021-04-30
 
 - Updated startTime argument in UpdateTransitionExecution (PATCH /transitions/:id/executions/:id) to be a datetime object and not a string.
 - Added UpdateWorkflowExecution (PATCH /workflows/:id/executions/:id)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
-#Changelog 
+# Changelog 
 
-##v1.16 -> v1.2.0:
+## v1.16 -> v1.2.0:
 
 - startTime argument in PATCH /transitions/:id/executions/:id can be supplied as datetime object.
 - PATCH /workflows/:id/executions/:id

--- a/Lucidtech/Las/Client.cs
+++ b/Lucidtech/Las/Client.cs
@@ -467,7 +467,7 @@ namespace Lucidtech.Las
         /// <example>
         /// <code>
         /// Client client = new Client();
-        /// var response = client.DeleteBatch("&lt;batch_id&gt;");
+        /// var response = client.DeleteBatch("&lt;batchId&gt;");
         /// </code>
         /// </example>
         /// <param name="batchId">Id of the batch</param>

--- a/Lucidtech/Las/Client.cs
+++ b/Lucidtech/Las/Client.cs
@@ -552,6 +552,20 @@ namespace Lucidtech.Las
             return ExecuteRequestResilient(RestSharpClient, request);
         }
 
+        /// <summary>Delete a secret, calls the DELETE /secrets/{secret_id} endpoint.
+        /// <example>
+        /// <code>
+        /// Client client = new Client();
+        /// var response = client.DeleteSecret("&lt;secret_id&gt;");
+        /// </code>
+        /// </example>
+        /// <param name="secretId">Id of the secret</param>
+        /// <returns>Secret response from REST API</returns>
+        public object DeleteSecret(string secretId) {
+            var request = ClientRestRequest(Method.DELETE, $"/secrets/{secretId}");
+            return ExecuteRequestResilient(RestSharpClient, request);
+        }
+
         /// <summary>Creates a transition, calls the POST /transitions endpoint.</summary>
         /// <example>
         /// <code>

--- a/Lucidtech/Las/Client.cs
+++ b/Lucidtech/Las/Client.cs
@@ -1218,7 +1218,7 @@ namespace Lucidtech.Las
         ///     {"environmentSecrets", environmentSecrets}
         /// };
         /// var errorConfig = new Dictionary<string, object>{
-        ///     {"email", "foo@lucid.com"},
+        ///     {"email", "foo@example.com"},
         ///     {"manualRetry", true}
         /// };
         /// var parameters = new Dictionary<string, string?>{

--- a/Lucidtech/Las/Client.cs
+++ b/Lucidtech/Las/Client.cs
@@ -1477,7 +1477,7 @@ namespace Lucidtech.Las
         /// use: las:transition:commons-failed</param>
         /// <returns>WorkflowExecution response from REST API</returns>
         public object UpdateWorkflowExecution(string workflowId, string executionId, string nextTransitionId) {
-            var body = new Dictionary<string, string>(){
+            var body = new Dictionary<string, string>() {
                 {"nextTransitionId", nextTransitionId}
             };
             var request = ClientRestRequest(Method.PATCH, $"/workflows/{workflowId}/executions/{executionId}", body);

--- a/Lucidtech/Las/Client.cs
+++ b/Lucidtech/Las/Client.cs
@@ -394,6 +394,7 @@ namespace Lucidtech.Las
         /// Client client = new Client();
         /// var response = client.DeleteConsent('&lt;consentId&gt;');
         /// </code></example>
+        /// <param name="batchId"> Delete documents with provided batchId </param>
         /// <param name="consentId"> Delete documents with provided consentId </param>
         /// <param name="maxResults">Maximum number of items to delete</param>
         /// <param name="nextToken">Token to retrieve the next page</param>
@@ -401,8 +402,17 @@ namespace Lucidtech.Las
         /// A deserialized object that can be interpreted as a Dictionary with the fields
         /// consentId, nextToken and documents
         /// </returns>
-        public object DeleteDocuments(string? consentId = null, int? maxResults = null, string? nextToken = null) {
+        public object DeleteDocuments(
+            string? batchId = null, 
+            string? consentId = null, 
+            int? maxResults = null, 
+            string? nextToken = null
+        ) {
             var queryParams = new Dictionary<string, object?>();
+
+            if (batchId != null) {
+                queryParams.Add("batchId", batchId);
+            }
 
             if (consentId != null) {
                 queryParams.Add("consentId", consentId);

--- a/Lucidtech/Las/Client.cs
+++ b/Lucidtech/Las/Client.cs
@@ -45,8 +45,8 @@ namespace Lucidtech.Las
         /// var response = Toby.CreateAppClient(
         ///     attributes: parameters, 
         ///     generateSecret: false,
-        ///     logoutUrls: new List<string>{"https://localhost/logout:3030"},
-        ///     callbackUrls: new List<string>{"https://localhost/callback:3030"}
+        ///     logoutUrls: new List<string>{"https://localhost:3030/logout"},
+        ///     callbackUrls: new List<string>{"https://localhost:3030/callback"}
         /// );
         /// </code>
         /// </example>

--- a/Lucidtech/Las/Client.cs
+++ b/Lucidtech/Las/Client.cs
@@ -474,7 +474,7 @@ namespace Lucidtech.Las
         /// <param name="deleteDocuments">delete all documents in the batch</param>
         /// <returns>Batch response from REST API</returns>
         public object DeleteBatch(string batchId, bool deleteDocuments = false) {
-            if (deleteDocuments == true){
+            if (deleteDocuments == true) {
                 var objectResponse = this.DeleteDocuments(batchId: batchId);
                 var response = JsonSerialPublisher.ObjectToDict<Dictionary<string, object>>(objectResponse);
                 while (response["nextToken"] != null)

--- a/Lucidtech/Las/Client.cs
+++ b/Lucidtech/Las/Client.cs
@@ -1463,7 +1463,7 @@ namespace Lucidtech.Las
 
         /// <summary>
         /// Retry or end the processing of a workflow execution,
-        /// calls the PATCH /workflows/{workflow_id}/executions/{execution_id} endpoint.
+        /// calls the PATCH /workflows/{workflowId}/executions/{executionId} endpoint.
         /// </summary>
         /// <example>
         /// <code>

--- a/Lucidtech/Las/Client.cs
+++ b/Lucidtech/Las/Client.cs
@@ -1205,6 +1205,29 @@ namespace Lucidtech.Las
         }
 
         /// <summary>
+        /// Retry or end the processing of a workflow execution,
+        /// calls the PATCH /workflows/{workflow_id}/executions/{execution_id} endpoint.
+        /// </summary>
+        /// <example>
+        /// <code>
+        /// Client client = new Client();
+        /// var response = client.UpdateWorkflowExecution("&lt;workflow_id&gt;", "&lt;execution_id&gt;", "&lt;next_transition_id&gt;");
+        /// </code>
+        /// </example>
+        /// <param name="workflowId">Id of the workflow</param>
+        /// <param name="executionId">Id of the execution</param>
+        /// <param name="nextTransitionId">The next transition to transition into, to end the workflow-execution,
+        /// use: las:transition:commons-failed</param>
+        /// <returns>WorkflowExecution response from REST API</returns>
+        public object UpdateWorkflowExecution(string workflowId, string executionId, string nextTransitionId) {
+            var body = new Dictionary<string, string>(){
+                {"nextTransitionId", nextTransitionId}
+            };
+            var request = ClientRestRequest(Method.PATCH, $"/workflows/{workflowId}/executions/{executionId}", body);
+            return ExecuteRequestResilient(RestSharpClient, request);
+        }
+
+        /// <summary>
         /// Deletes the execution with the provided execution_id from workflow_id,
         /// calls the DELETE /workflows/{workflowId}/executions/{executionId} endpoint.
         /// </summary>

--- a/Lucidtech/Las/Client.cs
+++ b/Lucidtech/Las/Client.cs
@@ -829,7 +829,7 @@ namespace Lucidtech.Las
             string status,
             Dictionary<string, string>? output = null,
             Dictionary<string, string>? error = null,
-            string? startTime = null
+            DateTime? startTime = null
         ) {
             var url = $"/transitions/{transitionId}/executions/{executionId}";
             var body = new Dictionary<string, object>{
@@ -845,7 +845,7 @@ namespace Lucidtech.Las
             }
 
             if (startTime != null) {
-                body.Add("startTime", startTime);
+                body.Add("startTime", startTime.Value.ToString("yyyy-MM-ddTHH:mm:ss.ffffzzz"));
             }
 
             var request = ClientRestRequest(Method.PATCH, url, body);

--- a/Lucidtech/Las/Client.cs
+++ b/Lucidtech/Las/Client.cs
@@ -58,7 +58,7 @@ namespace Lucidtech.Las
             List<string>? callbackUrls = null,
             Dictionary<string, string?>? attributes = null
         ) {
-            var body = new Dictionary<string, object>(){
+            var body = new Dictionary<string, object>() {
                 {"generateSecret", generateSecret}
             };
             

--- a/Lucidtech/Las/Client.cs
+++ b/Lucidtech/Las/Client.cs
@@ -38,15 +38,15 @@ namespace Lucidtech.Las
         /// <summary>Creates an appClient, calls the POST /appClients endpoint.</summary>
         /// <example>
         /// <code>
-        /// var parameters = new Dictionary<string, string?>{
+        /// var parameters = new Dictionary&lt;string, string?&gt;{
         ///     {"name", name},
         ///     {"description", description},
         /// };
         /// var response = Toby.CreateAppClient(
         ///     attributes: parameters, 
         ///     generateSecret: false,
-        ///     logoutUrls: new List<string>{"https://localhost:3030/logout"},
-        ///     callbackUrls: new List<string>{"https://localhost:3030/callback"}
+        ///     logoutUrls: new List&lt;string&gt;{"https://localhost:3030/logout"},
+        ///     callbackUrls: new List&lt;string&gt;{"https://localhost:3030/callback"}
         /// );
         /// </code>
         /// </example>
@@ -969,7 +969,7 @@ namespace Lucidtech.Las
         ) {
             List<string>? statuses = null;
             if (status != null) {
-                statuses = new List<string>{status};
+                statuses = new List<string> {status};
             }
             return ListTransitionExecutions(transitionId, statuses, executionIds, maxResults, nextToken, sortBy, order);
          }
@@ -1053,7 +1053,7 @@ namespace Lucidtech.Las
             DateTime? startTime = null
         ) {
             var url = $"/transitions/{transitionId}/executions/{executionId}";
-            var body = new Dictionary<string, object>{
+            var body = new Dictionary<string, object> {
                 {"status", status},
             };
 
@@ -1101,7 +1101,7 @@ namespace Lucidtech.Las
         /// <param name="attributes">Additional attributes. Currently supported are: name, avatar</param>
         /// <returns>User response from REST API</returns>
         public object CreateUser(string email, Dictionary<string, string?>? attributes = null) {
-            var body = new Dictionary<string, string>{
+            var body = new Dictionary<string, string> {
                 {"email", email}
             };
 
@@ -1209,19 +1209,19 @@ namespace Lucidtech.Las
         ///     {"version", "1.0.0"},
         ///     {"definition", {...}}
         /// };
-        /// var environmentSecrets = new List<string>{ "las:secret:<hex-uuid>" };
-        /// var env = new Dictionary<string, string>{{"FOO", "BAR"}};
-        /// var completedConfig = new Dictionary<string, object>{
+        /// var environmentSecrets = new List&lt;string&gt;{ "las:secret:&lt;hex-uuid&gt;" };
+        /// var env = new Dictionary&lt;string, string&gt;{{"FOO", "BAR"}};
+        /// var completedConfig = new Dictionary&lt;string, object&gt;{
         ///     {"imageUrl", "my/docker:image"},
         ///     {"secretId", secretId},
         ///     {"environment", env},
         ///     {"environmentSecrets", environmentSecrets}
         /// };
-        /// var errorConfig = new Dictionary<string, object>{
+        /// var errorConfig = new Dictionary&lt;string, object&gt;{
         ///     {"email", "foo@example.com"},
         ///     {"manualRetry", true}
         /// };
-        /// var parameters = new Dictionary<string, string?>{
+        /// var parameters = new Dictionary&lt;string, string?&gt;{
         ///     {"name", name},
         ///     {"description", description}
         /// };
@@ -1239,7 +1239,7 @@ namespace Lucidtech.Las
             Dictionary<string, object>? completedConfig = null,
             Dictionary<string, string?>? attributes = null
         ) {
-            var body = new Dictionary<string, object?>{
+            var body = new Dictionary<string, object?> { 
                 {"specification", specification}
             };
 
@@ -1306,7 +1306,7 @@ namespace Lucidtech.Las
             Dictionary<string, object>? completedConfig,
             Dictionary<string, string?> attributes
         ){
-            var body = new Dictionary<string, object?>{};
+            var body = new Dictionary<string, object?> {};
             
             if (errorConfig != null) {
                 body.Add("errorConfig", errorConfig);
@@ -1397,7 +1397,7 @@ namespace Lucidtech.Las
             string? nextToken = null,
             string? sortBy = null,
             string? order = null
-        ) => ListWorkflowExecutions(workflowId, new List<string>{status}, maxResults, nextToken, sortBy, order);
+        ) => ListWorkflowExecutions(workflowId, new List<string> {status}, maxResults, nextToken, sortBy, order);
 
         /// <summary>List executions in a workflow, calls the GET /workflows/{workflowId}/executions endpoint.</summary>
         /// <example>

--- a/Lucidtech/Las/Client.cs
+++ b/Lucidtech/Las/Client.cs
@@ -714,6 +714,9 @@ namespace Lucidtech.Las
             string transitionId,
             Dictionary<string, string>? inputJsonSchema,
             Dictionary<string, string>? outputJsonSchema,
+            Dictionary<string, string>? assets,
+            Dictionary<string, string>? environment,
+            List<string>? environmentSecrets,
             Dictionary<string, string?> attributes
         ) {
             var body = new Dictionary<string, object?>();
@@ -726,6 +729,18 @@ namespace Lucidtech.Las
                 body.Add("outputJsonSchema", outputJsonSchema);
             }
 
+            if (assets != null) {
+                body.Add("assets", assets);
+            }
+
+            if (environment != null) {
+                body.Add("environment", environment);
+            }
+
+            if (environmentSecrets != null) {
+                body.Add("environmentSecrets", environmentSecrets);
+            }
+            
             if (attributes != null) {
                 foreach (KeyValuePair<string, string?> entry in attributes) {
                     body.Add(entry.Key, entry.Value);

--- a/Lucidtech/Las/Client.cs
+++ b/Lucidtech/Las/Client.cs
@@ -463,7 +463,7 @@ namespace Lucidtech.Las
             return ExecuteRequestResilient(RestSharpClient, request);
         }
 
-        /// <summary>Delete a batch, calls the DELETE /batches/{batch_id} endpoint.
+        /// <summary>Delete a batch, calls the DELETE /batches/{batchId} endpoint.
         /// <example>
         /// <code>
         /// Client client = new Client();

--- a/Lucidtech/Las/Client.cs
+++ b/Lucidtech/Las/Client.cs
@@ -34,6 +34,95 @@ namespace Lucidtech.Las
         /// Client constructor with credentials read from local file.
         /// </summary>
         public Client() : this(new Credentials()) {}
+        
+        /// <summary>Creates an appClient, calls the POST /appClients endpoint.</summary>
+        /// <example>
+        /// <code>
+        /// var parameters = new Dictionary<string, string?>{
+        ///     {"name", name},
+        ///     {"description", description},
+        /// };
+        /// var response = Toby.CreateAppClient(
+        ///     attributes: parameters, 
+        ///     generateSecret: false,
+        ///     logoutUrls: new List<string>{"https://localhost/logout:3030"},
+        ///     callbackUrls: new List<string>{"https://localhost/callback:3030"}
+        /// );
+        /// </code>
+        /// </example>
+        /// <param name="attributes">Additional attributes</param>
+        /// <returns>AppClient response from REST API</returns>
+        public object CreateAppClient(
+            bool generateSecret = true, 
+            List<string>? logoutUrls = null, 
+            List<string>? callbackUrls = null,
+            Dictionary<string, string?>? attributes = null
+        ) {
+            var body = new Dictionary<string, object>(){
+                {"generateSecret", generateSecret}
+            };
+            
+            if (logoutUrls != null) {
+                body.Add("logoutUrls", logoutUrls);
+            }
+
+            if (callbackUrls != null) {
+                body.Add("callbackUrls", callbackUrls);
+            }
+            
+            if (attributes != null) {
+                foreach (KeyValuePair<string, string?> entry in attributes) {
+                    body.Add(entry.Key, entry.Value);
+                }
+            }
+
+            RestRequest request = ClientRestRequest(Method.POST, "/appClients", body);
+            return ExecuteRequestResilient(RestSharpClient, request);
+        }
+
+        /// <summary> List available appClients, calls the GET /appClients endpoint. </summary>
+        /// <example>
+        /// <code>
+        /// Client client = new Client();
+        /// var response = client.ListAppClients();
+        /// </code>
+        /// </example>
+        /// <param name="maxResults">Number of items to show on a single page</param>
+        /// <param name="nextToken">Token to retrieve the next page</param>
+        /// <returns>
+        /// JSON object with two keys:
+        /// - "appClients" AppClients response from REST API without the content of each appClient
+        /// - "nextToken" allowing for retrieving the next portion of data
+        /// </returns>
+        public object ListAppClients(int? maxResults = null, string? nextToken = null) {
+            var queryParams = new Dictionary<string, object?>();
+
+            if (maxResults != null) {
+                queryParams.Add("maxResults", maxResults.ToString());
+            }
+
+            if (nextToken != null) {
+                queryParams.Add("nextToken", nextToken);
+            }
+
+            RestRequest request = ClientRestRequest(Method.GET, "/appClients", null, queryParams);
+            return ExecuteRequestResilient(RestSharpClient, request);
+        }
+
+        /// <summary>Delete an appClient, calls the DELETE /appClients/{appClientId} endpoint.
+        /// <example>
+        /// <code>
+        /// Client client = new Client();
+        /// var response = client.DeleteAppClient("&lt;appClientId&gt;");
+        /// </code>
+        /// </example>
+        /// <param name="appClientId">Id of the appClient</param>
+        /// <returns>AppClient response from REST API</returns>
+        public object DeleteAppClient(string appClientId) {
+            var request = ClientRestRequest(Method.DELETE, $"/appClients/{appClientId}");
+            return ExecuteRequestResilient(RestSharpClient, request);
+        }
+
 
         /// <summary>Creates an asset, calls the POST /assets endpoint.</summary>
         /// <example>

--- a/Lucidtech/Las/Client.cs
+++ b/Lucidtech/Las/Client.cs
@@ -228,7 +228,7 @@ namespace Lucidtech.Las
         /// <example>
         /// <code>
         /// Client client = new Client();
-        /// var response = client.DeleteAsset("&lt;asset_id&gt;");
+        /// var response = client.DeleteAsset("&lt;assetId&gt;");
         /// </code>
         /// </example>
         /// <param name="assetId">Id of the asset</param>

--- a/Lucidtech/Las/Client.cs
+++ b/Lucidtech/Las/Client.cs
@@ -1204,6 +1204,21 @@ namespace Lucidtech.Las
             return ExecuteRequestResilient(RestSharpClient, request);
         }
 
+        /// <summary>Get an execution of a workflow, calls the GET /workflows/{workflowId}/executions/{executionId} endpoint</summary>
+        /// <example>
+        /// <code>
+        /// Client client = new Client();
+        /// var response = client.GetWorkflowExecution("&lt;workflow_id&gt;", "&lt;execution_id&gt;");
+        /// </code>
+        /// </example>
+        /// <param name="workflowId">Id of the workflow</param>
+        /// <param name="executionId">Id of the execution</param>
+        /// <returns>Workflow execution response from REST API</returns>
+        public object GetWorkflowExecution(string workflowId, string executionId) {
+            RestRequest request = ClientRestRequest(Method.GET, $"/workflows/{workflowId}/executions/{executionId}");
+            return ExecuteRequestResilient(RestSharpClient, request);
+        }
+
         /// <summary>
         /// Retry or end the processing of a workflow execution,
         /// calls the PATCH /workflows/{workflow_id}/executions/{execution_id} endpoint.

--- a/Lucidtech/Las/Client.cs
+++ b/Lucidtech/Las/Client.cs
@@ -983,36 +983,51 @@ namespace Lucidtech.Las
         /// <example>
         /// <code>
         /// Client client = new Client();
-        /// var spec = new Dictionary&lt;string, object&gt;{
+        /// var specification = new Dictionary&lt;string, object&gt;{
         ///     {"language", "ASL"},
         ///     {"version", "1.0.0"},
         ///     {"definition", {...}}
         /// };
-        /// var errorConfig = new Dictionary&lt;string, string&gt;{
-        ///     {"email", "foo@bar.com}
+        /// var environmentSecrets = new List<string>{ "las:secret:<hex-uuid>" };
+        /// var env = new Dictionary<string, string>{{"FOO", "BAR"}};
+        /// var completedConfig = new Dictionary<string, object>{
+        ///     {"imageUrl", "my/docker:image"},
+        ///     {"secretId", secretId},
+        ///     {"environment", env},
+        ///     {"environmentSecrets", environmentSecrets}
         /// };
-        /// var parameters = new Dictionary&lt;string, string&gt;{
-        ///     {"name", "Name"},
-        ///     {"description", "My awesome workflow"}
+        /// var errorConfig = new Dictionary<string, object>{
+        ///     {"email", "foo@lucid.com"},
+        ///     {"manualRetry", true}
         /// };
-        /// var response = Client.CreateWorkflow(spec, errorConfig, parameters);
+        /// var parameters = new Dictionary<string, string?>{
+        ///     {"name", name},
+        ///     {"description", description}
+        /// };
+        /// var response = Toby.CreateWorkflow(spec, errorConfig, completedConfig, parameters);
         /// </code>
         /// </example>
-        /// <param name="spec">Workflow specification. Currently only ASL is supported: https://states-language.net/spec.html</param>
+        /// <param name="specification">Workflow specification. Currently only ASL is supported: https://states-language.net/spec.html</param>
         /// <param name="errorConfig">Error handler configuration</param>
+        /// <param name="completedConfig">Configuration of a job to run whenever a workflow execution ends</param>
         /// <param name="attributes">Additional attributes. Currently supported are: name, description.</param>
         /// <returns>Workflow response from REST API</returns>
         public object CreateWorkflow(
-            Dictionary<string, object> spec,
-            Dictionary<string, string>? errorConfig = null,
+            Dictionary<string, object> specification,
+            Dictionary<string, object>? errorConfig = null,
+            Dictionary<string, object>? completedConfig = null,
             Dictionary<string, string?>? attributes = null
         ) {
             var body = new Dictionary<string, object?>{
-                {"specification", spec}
+                {"specification", specification}
             };
 
             if (errorConfig != null) {
                 body.Add("errorConfig", errorConfig);
+            }
+
+            if (completedConfig != null) {
+                body.Add("completedConfig", completedConfig);
             }
 
             if (attributes != null) {

--- a/Lucidtech/Las/Client.cs
+++ b/Lucidtech/Las/Client.cs
@@ -463,6 +463,33 @@ namespace Lucidtech.Las
             return ExecuteRequestResilient(RestSharpClient, request);
         }
 
+        /// <summary>Delete a batch, calls the DELETE /batches/{batch_id} endpoint.
+        /// <example>
+        /// <code>
+        /// Client client = new Client();
+        /// var response = client.DeleteBatch("&lt;batch_id&gt;");
+        /// </code>
+        /// </example>
+        /// <param name="batchId">Id of the batch</param>
+        /// <param name="deleteDocuments">delete all documents in the batch</param>
+        /// <returns>Batch response from REST API</returns>
+        public object DeleteBatch(string batchId, bool deleteDocuments = false) {
+            if (deleteDocuments == true){
+                var objectResponse = this.DeleteDocuments(batchId: batchId);
+                var response = JsonSerialPublisher.ObjectToDict<Dictionary<string, object>>(objectResponse);
+                while (response["nextToken"] != null)
+                {
+                    objectResponse = this.DeleteDocuments(
+                        batchId: batchId, 
+                        nextToken: response["nextToken"].ToString()
+                    );
+                    response = JsonSerialPublisher.ObjectToDict<Dictionary<string, object>>(objectResponse);
+                }
+            }
+            var request = ClientRestRequest(Method.DELETE, $"/batches/{batchId}");
+            return ExecuteRequestResilient(RestSharpClient, request);
+        }
+
         /// <summary>
         /// Run inference and create a prediction, calls the POST /predictions endpoint.
         /// </summary>

--- a/Lucidtech/Las/Client.cs
+++ b/Lucidtech/Las/Client.cs
@@ -135,6 +135,20 @@ namespace Lucidtech.Las
             return ExecuteRequestResilient(RestSharpClient, request);
         }
 
+        /// <summary>Delete an asset, calls the DELETE /assets/{asset_id} endpoint.
+        /// <example>
+        /// <code>
+        /// Client client = new Client();
+        /// var response = client.DeleteAsset("&lt;asset_id&gt;");
+        /// </code>
+        /// </example>
+        /// <param name="assetId">Id of the asset</param>
+        /// <returns>Asset response from REST API</returns>
+        public object DeleteAsset(string assetId) {
+            var request = ClientRestRequest(Method.DELETE, $"/assets/{assetId}");
+            return ExecuteRequestResilient(RestSharpClient, request);
+        }
+
         /// <summary>
         /// Creates a document handle, calls the POST /documents endpoint
         /// </summary>

--- a/Lucidtech/Las/Client.cs
+++ b/Lucidtech/Las/Client.cs
@@ -224,7 +224,7 @@ namespace Lucidtech.Las
             return ExecuteRequestResilient(RestSharpClient, request);
         }
 
-        /// <summary>Delete an asset, calls the DELETE /assets/{asset_id} endpoint.
+        /// <summary>Delete an asset, calls the DELETE /assets/{assetId} endpoint.
         /// <example>
         /// <code>
         /// Client client = new Client();

--- a/Lucidtech/Las/Client.cs
+++ b/Lucidtech/Las/Client.cs
@@ -1122,8 +1122,29 @@ namespace Lucidtech.Las
         /// <param name="workflowId">Id of the workflow</param>
         /// <param name="attributes">Attributes to update. Currently supported are: name, description</param>
         /// <returns>Workflow response from REST API</returns>
-        public object UpdateWorkflow(string workflowId, Dictionary<string, string?> attributes) {
-            var request = ClientRestRequest(Method.PATCH, $"/workflows/{workflowId}", attributes);
+        public object UpdateWorkflow(
+            string workflowId, 
+            Dictionary<string, object>? errorConfig,
+            Dictionary<string, object>? completedConfig,
+            Dictionary<string, string?> attributes
+        ){
+            var body = new Dictionary<string, object?>{};
+            
+            if (errorConfig != null) {
+                body.Add("errorConfig", errorConfig);
+            }
+
+            if (completedConfig != null) {
+                body.Add("completedConfig", completedConfig);
+            }
+
+            if (attributes != null) {
+                foreach (KeyValuePair<string, string?> entry in attributes) {
+                    body.Add(entry.Key, entry.Value);
+                }
+            }
+
+            var request = ClientRestRequest(Method.PATCH, $"/workflows/{workflowId}", body);
             return ExecuteRequestResilient(RestSharpClient, request);
         }
 

--- a/Lucidtech/Las/Client.cs
+++ b/Lucidtech/Las/Client.cs
@@ -531,6 +531,58 @@ namespace Lucidtech.Las
             return ExecuteRequestResilient(RestSharpClient, request);
         }
 
+        /// <summary>List logs, calls the GET /logs endpoint.</summary>
+        /// <example>
+        /// <code>
+        /// Client client = new Client();
+        /// var response = client.ListLogs();
+        /// </code>
+        /// </example>
+        /// <param name="transitionId">Only show logs from this transition</param>
+        /// <param name="transitionExecutionId">Only show logs from this transition execution</param>
+        /// <param name="workflowId">Only show logs from this workflow</param>
+        /// <param name="workflowExecutionId">Only show logs from this workflow execution</param>
+        /// <param name="maxResults">Number of items to show on a single page</param>
+        /// <param name="nextToken">Token to retrieve the next page</param>
+        /// <returns>Logs response from REST API</returns>
+        public object ListLogs(
+            string? transitionId = null, 
+            string? transitionExecutionId = null, 
+            string? workflowId = null, 
+            string? workflowExecutionId = null, 
+            int? maxResults = null, 
+            string? nextToken = null
+        ) {
+            var queryParams = new Dictionary<string, object?>();
+
+            if (transitionId != null) {
+                queryParams.Add("transitionId", transitionId);
+            }
+
+            if (transitionExecutionId != null) {
+                queryParams.Add("transitionExecutionId", transitionExecutionId);
+            }
+
+            if (workflowId != null) {
+                queryParams.Add("workflowId", workflowId);
+            }
+
+            if (workflowExecutionId != null) {
+                queryParams.Add("workflowExecutionId", workflowExecutionId);
+            }
+
+            if (maxResults != null) {
+                queryParams.Add("maxResults", maxResults.ToString());
+            }
+
+            if (nextToken != null) {
+                queryParams.Add("nextToken", nextToken);
+            }
+
+            RestRequest request = ClientRestRequest(Method.GET, "/logs", null, queryParams);
+            return ExecuteRequestResilient(RestSharpClient, request);
+        }
+
         /// <summary>List models available, calls the GET /models endpoint.</summary>
         /// <example>
         /// <code>

--- a/Lucidtech/Las/Client.cs
+++ b/Lucidtech/Las/Client.cs
@@ -734,7 +734,7 @@ namespace Lucidtech.Las
         /// <example>
         /// <code>
         /// Client client = new Client();
-        /// var response = client.DeleteSecret("&lt;secret_id&gt;");
+        /// var response = client.DeleteSecret("&lt;secretId&gt;");
         /// </code>
         /// </example>
         /// <param name="secretId">Id of the secret</param>

--- a/Lucidtech/Las/Client.cs
+++ b/Lucidtech/Las/Client.cs
@@ -730,7 +730,7 @@ namespace Lucidtech.Las
             return ExecuteRequestResilient(RestSharpClient, request);
         }
 
-        /// <summary>Delete a secret, calls the DELETE /secrets/{secret_id} endpoint.
+        /// <summary>Delete a secret, calls the DELETE /secrets/{secretId} endpoint.
         /// <example>
         /// <code>
         /// Client client = new Client();

--- a/Lucidtech/Las/Client.cs
+++ b/Lucidtech/Las/Client.cs
@@ -471,7 +471,7 @@ namespace Lucidtech.Las
         /// </code>
         /// </example>
         /// <param name="batchId">Id of the batch</param>
-        /// <param name="deleteDocuments">delete all documents in the batch</param>
+        /// <param name="deleteDocuments">Set to true to delete documents in batch before deleting batch</param>
         /// <returns>Batch response from REST API</returns>
         public object DeleteBatch(string batchId, bool deleteDocuments = false) {
             if (deleteDocuments == true) {

--- a/Lucidtech/Lucidtech.csproj
+++ b/Lucidtech/Lucidtech.csproj
@@ -24,7 +24,7 @@
     <PackageLicenseUrl>https://www.apache.org/licenses/LICENSE-2.0</PackageLicenseUrl>
     <RepositoryUrl>https://github.com/LucidtechAI/las-sdk-net</RepositoryUrl>
     <PackageTags>las Lucidtech invoice receipt intelligentOCR Automation DeepLearning MachineLearning OCR Document DataExtraction</PackageTags>
-    <PackageReleaseNotes>See complete changelog</PackageReleaseNotes>
+    <PackageReleaseNotes>See complete changelog: https://github.com/LucidtechAI/las-sdk-net/blob/master/CHANGELOG.md</PackageReleaseNotes>
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/Lucidtech/Lucidtech.csproj
+++ b/Lucidtech/Lucidtech.csproj
@@ -15,7 +15,7 @@
     <TargetFrameworks>netstandard20</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageId>Lucidtech.Las</PackageId>
-    <PackageVersion>1.1.6</PackageVersion>
+    <PackageVersion>1.2.0</PackageVersion>
     <Title>Lucidtech AI Services</Title>
     <Authors>Lucidtech AS</Authors>
     <Description>SDK for accessing Lucidtech AI Services</Description>
@@ -24,7 +24,7 @@
     <PackageLicenseUrl>https://www.apache.org/licenses/LICENSE-2.0</PackageLicenseUrl>
     <RepositoryUrl>https://github.com/LucidtechAI/las-sdk-net</RepositoryUrl>
     <PackageTags>las Lucidtech invoice receipt intelligentOCR Automation DeepLearning MachineLearning OCR Document DataExtraction</PackageTags>
-    <PackageReleaseNotes>Add queryparameters in DeleteDocuments and fix important bug for queryparams</PackageReleaseNotes>
+    <PackageReleaseNotes>See complete changelog</PackageReleaseNotes>
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,10 @@ test: build-test
 	mono $(HOME)/.nuget/packages/nunit.consolerunner/3.11.1/tools/nunit3-console.exe --stoponerror ./Test/bin/Debug/net47/Test.dll
 	mono $(HOME)/.nuget/packages/nunit.consolerunner/3.11.1/tools/nunit3-console.exe --stoponerror ./Test/bin/Debug/net472/Test.dll
 
+single-test: build-test
+	if [ -z "$(name)" ]; then echo 'you need to specify the name of your test ex. name=TestDeleteBatch' && exit 1; fi
+	mono $(HOME)/.nuget/packages/nunit.consolerunner/3.11.1/tools/nunit3-console.exe --stoponerror ./Test/bin/Debug/net472/Test.dll --test=Test.TestClient.$(name)
+	
 prism-start:
 	@echo "Starting mock API..."
 	docker run \

--- a/Makefile
+++ b/Makefile
@@ -18,12 +18,6 @@ build-test: restore-test
 	msbuild Test/Test.csproj
 
 test: build-test
-	nunit3-console ./Test/bin/Debug/net461/Test.dll
-	nunit3-console ./Test/bin/Debug/net47/Test.dll
-	nunit3-console ./Test/bin/Debug/net472/Test.dll
-
-test2: build-test
-	# this target is needed to run nunit3-console on macos
 	mono $(HOME)/.nuget/packages/nunit.consolerunner/3.11.1/tools/nunit3-console.exe --stoponerror ./Test/bin/Debug/net461/Test.dll
 	mono $(HOME)/.nuget/packages/nunit.consolerunner/3.11.1/tools/nunit3-console.exe --stoponerror ./Test/bin/Debug/net47/Test.dll
 	mono $(HOME)/.nuget/packages/nunit.consolerunner/3.11.1/tools/nunit3-console.exe --stoponerror ./Test/bin/Debug/net472/Test.dll

--- a/README.md
+++ b/README.md
@@ -91,3 +91,4 @@ $ # Build for release and make nuget package
 $ msbuild Lucidtech/Lucidtech.csproj /t:Rebuild /p:Configuration=Release
 ```
 
+Hint: Set environment variable CREDENTIALS=FROM_FILE to run a test against the real API with your default credentials.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 ## Documentation
 
-[Link to docs](https://docs.lucidtech.ai/dotnet/v1/index.html)
+[Link to docs](https://docs.lucidtech.ai/reference/dotnet/latest)
+
 
 Create documents by using doxygen.
 Download the latest and greatest version of [doxygen](https://github.com/doxygen/doxygen.git).

--- a/README.md
+++ b/README.md
@@ -32,37 +32,7 @@ $ nuget install Lucidtech.Las
 - Necessary keys and credentials to an endpoint on the form: "https://<your prefix>.api.lucidtech.ai/<version>".
 
 ### Quick start
-
-Run inference and create prediction on document 
-```C#
-using Lucidtech.Las;
-
-ApiClient apiClient = new ApiClient("<endpoint>");
-Prediction response = apiClient.Predict(documentPath: "document.pdf", modelName: "invoice|receipt|documentSplit");
-Console.WriteLine(response.ToJsonString(Formatting.Indented));
-```
-
-Send feedback to the model.
-```C#
-using Lucidtech.Las;
-
-var feedback = new List<Dictionary<string, string>>()
-{ 
-    new Dictionary<string, string>(){{"label", "total_amount"},{"value", "54.50"}},
-    new Dictionary<string, string>(){{"label", "purchase_date"},{"value", "2007-07-30"}}
-};
-FeedbackResponse response = apiClient.SendFeedback(documentId: "<documentId>", feedback: feedback);
-Console.WriteLine(response.ToJsonString(Formatting.Indented));
-```
-
-Revoke consent and deleting all documents associated with consentId.
-```C#
-using Lucidtech.Las;
-
-ApiClient apiClient = new ApiClient("<endpoint>");
-RevokeResponse response = apiClient.RevokeConsent(consentId: "<consentId>");
-Console.WriteLine(response.ToJsonString(Formatting.Indented));
-```
+See [docs](https://docs.lucidtech.ai/getting-started/dev/net).
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -46,9 +46,9 @@ Download the following packages:
 
 ### Prerequisites for Arch Users
 Download the following packages: 
-* The latest and greatest stable version of [MSBuild](https://aur.archlinux.org/pkgbase/msbuild/)
+* The latest and greatest stable version of [MSBuild](https://aur.archlinux.org/packages/msbuild-git/)
 * The latest and greatest version of [NuGet](https://aur.archlinux.org/packages/nuget3/)
-* [nunit](https://aur.archlinux.org/nunit3-console.git) version 3.9.0 or higher to run tests from command line
+* [nunit](https://aur.archlinux.org/packages/nunit3-console/) version 3.9.0 or higher to run tests from command line
 * [.NET-SDK](https://www.archlinux.org/packages/community/x86_64/dotnet-sdk/) version 2.2.105
 
 ### Build and run tests

--- a/Test/Service.cs
+++ b/Test/Service.cs
@@ -23,20 +23,22 @@ namespace Test.Service
                     return new [] {"assetId", "name", "description"};
                 case "assets": 
                     return new [] {"nextToken", "assets"};
-                case "document":
-                    return new [] {"documentId", "contentType", "consentId", "groundTruth"};
-                case "documents": 
-                    return new [] {"nextToken", "documents"};
-                case "prediction":
-                    return new [] {"documentId", "predictions"};
-                case "predictions":
-                    return new [] {"predictions"};
                 case "batch":
                     return new[] {"name", "description", "batchId"};
                 case "batches":
                     return new[] {"batches", "nextToken"};
+                case "document":
+                    return new [] {"documentId", "contentType", "consentId", "groundTruth"};
+                case "documents": 
+                    return new [] {"nextToken", "documents"};
+                case "logs":
+                    return new[] {"logs", "nextToken"};
                 case "models":
                     return new[] {"models", "nextToken"};
+                case "prediction":
+                    return new [] {"documentId", "predictions"};
+                case "predictions":
+                    return new [] {"predictions"};
                 case "secret":
                     return new [] {"secretId", "name", "description"};
                 case "secrets": 

--- a/Test/Service.cs
+++ b/Test/Service.cs
@@ -63,6 +63,33 @@ namespace Test.Service
                     throw new Exception($"{resourceName} is not a valid resource name");
             }
         }
+        
+        public static Dictionary<string, object> CompletedConfig(){
+            var environment = new Dictionary<string, string?>{
+                {"FOO", "FOO"},
+                {"BAR", "BAR"}
+            };
+            return new Dictionary<string, object>{
+                {"imageUrl", "my/docker:image"},
+                {"secretId", Util.ResourceId("secret")},
+                {"environment", environment},
+                {"environmentSecrets", new List<string>{Util.ResourceId("secret")}}
+            };
+        }
+            
+        public static Dictionary<string, object> ErrorConfig(){
+            return new Dictionary<string, object>{
+                {"email", "foo@lucidtech.io"},
+                {"manualRetry", true}
+            };
+        }
+            
+        public static Dictionary<string, string?> NameAndDescription(string? name, string? description){
+            return new Dictionary<string, string?>{
+                {"name", name},
+                {"description", description}
+            };
+        }
     }
     
 }

--- a/Test/Service.cs
+++ b/Test/Service.cs
@@ -15,6 +15,10 @@ namespace Test.Service
         
         public static string[] ExpectedKeys(string resourceName){
             switch (resourceName) {
+                case "appClient":
+                    return new [] {"appClientId", "name", "description"};
+                case "appClients": 
+                    return new [] {"nextToken", "appClients"};
                 case "asset":
                     return new [] {"assetId", "name", "description"};
                 case "assets": 

--- a/Test/Service.cs
+++ b/Test/Service.cs
@@ -12,5 +12,57 @@ namespace Test.Service
         public static string ResourceId(string resourceName){
             return $"las:{resourceName}:{Guid.NewGuid().ToString().Replace("-", "")}";
         }
+        
+        public static string[] ExpectedKeys(string resourceName){
+            switch (resourceName) {
+                case "asset":
+                    return new [] {"assetId", "name", "description"};
+                case "assets": 
+                    return new [] {"nextToken", "assets"};
+                case "document":
+                    return new [] {"documentId", "contentType", "consentId", "groundTruth"};
+                case "documents": 
+                    return new [] {"nextToken", "documents"};
+                case "prediction":
+                    return new [] {"documentId", "predictions"};
+                case "predictions":
+                    return new [] {"predictions"};
+                case "batch":
+                    return new[] {"name", "description", "batchId"};
+                case "batches":
+                    return new[] {"batches", "nextToken"};
+                case "models":
+                    return new[] {"models", "nextToken"};
+                case "secret":
+                    return new [] {"secretId", "name", "description"};
+                case "secrets": 
+                    return new [] {"nextToken", "secrets"};
+                case "transition":
+                    return new [] {"transitionId", "name", "description", "transitionType"};
+                case "transitions": 
+                    return new [] {"nextToken", "transitions"};
+                case "transition-execution":
+                    return new [] {"transitionId", "executionId", "status", "completedBy", "endTime", "input", "logId", "startTime"};
+                case "transition-executions":
+                    return new [] {"nextToken", "executions"};
+                case "heartbeats":
+                    return new [] {"Your request executed successfully"};
+                case "user":
+                    return new [] {"userId", "name", "avatar", "email"};
+                case "users": 
+                    return new [] {"nextToken", "users"};
+                case "workflow":
+                    return new [] {"workflowId", "name", "description"};
+                case "workflows": 
+                    return new [] {"nextToken", "workflows"};
+                case "workflow-execution":
+                    return new [] {"workflowId", "executionId", "status", "completedBy", "endTime", "logId", "startTime", "transitionExecutions"};
+                case "workflow-executions":
+                    return new [] {"nextToken", "executions", "workflowType"};
+                default:
+                    throw new Exception($"{resourceName} is not a valid resource name");
+            }
+        }
     }
+    
 }

--- a/Test/Service.cs
+++ b/Test/Service.cs
@@ -1,0 +1,16 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Diagnostics;
+
+namespace Test.Service
+{
+
+    public static class Util {
+    
+        public static string ResourceId(string resourceName){
+            return $"las:{resourceName}:{Guid.NewGuid().ToString().Replace("-", "")}";
+        }
+    }
+}

--- a/Test/Test.cs
+++ b/Test/Test.cs
@@ -328,18 +328,35 @@ namespace Test
         [TestCase("foo", "bar")]
         [TestCase(null, null)]
         public void TestUpdateTransition(string? name, string? description) {
+            
             var schema = new Dictionary<string, string>() {
                 {"schema", "https://json-schema.org/draft-04/schema#"},
                 {"title", "response"}
             };
             var inputSchema = schema;
             var outputSchema = schema;
+            var assets = new Dictionary<string, string?>{
+                {"foo", $"las:asset:{Guid.NewGuid().ToString().Replace("-", "")}"},
+                {"bar",  $"las:asset:{Guid.NewGuid().ToString().Replace("-", "")}"}
+            };
+            var environment = new Dictionary<string, string?>{
+                {"FOO", "FOO"},
+                {"BAR", "BAR"}
+            };
+            var environmentSecrets = new List<string>{ $"las:secret:{Guid.NewGuid().ToString().Replace("-", "")}" };
             var transitionId = $"las:transition:{Guid.NewGuid().ToString().Replace("-", "")}";
             var parameters = new Dictionary<string, string?>{
                 {"name", name},
                 {"description", description}
             };
-            var response = Toby.UpdateTransition(transitionId, inputSchema, outputSchema, parameters);
+            var response = Toby.UpdateTransition(
+                transitionId, 
+                inputSchema, 
+                outputSchema, 
+                assets,
+                environment,
+                environmentSecrets,
+                parameters);
             CheckKeys(new [] {"transitionId", "name", "description", "transitionType"}, response);
         }
 

--- a/Test/Test.cs
+++ b/Test/Test.cs
@@ -524,10 +524,12 @@ namespace Test
         [TestCase("name", "")]
         [TestCase(null, null)]
         public void TestUpdateWorkflow(string name, string description) {
-            var response = Toby.UpdateWorkflow(Util.ResourceId("workflow"), new Dictionary<string, string?>{
-                {"name", name},
-                {"description", description}
-            });
+            var response = Toby.UpdateWorkflow(
+                Util.ResourceId("workflow"), 
+                errorConfig: Util.ErrorConfig(),
+                completedConfig: Util.CompletedConfig(),
+                attributes: Util.NameAndDescription(name, description)
+            );
             CheckKeys(Util.ExpectedKeys("workflow"), response);
         }
 

--- a/Test/Test.cs
+++ b/Test/Test.cs
@@ -598,6 +598,14 @@ namespace Test
         }
 
         [Test]
+        public void TestGetWorkflowExecution() {
+            var executionId = $"las:workflow-execution:{Guid.NewGuid().ToString().Replace("-", "")}";
+            var workflowId = $"las:workflow:{Guid.NewGuid().ToString().Replace("-", "")}";
+            var response = Toby.GetWorkflowExecution(workflowId, executionId);
+            CheckKeys(new [] {"workflowId", "executionId"}, response);
+        }
+
+        [Test]
         public void TestUpdateWorkflowExecution() {
             var workflowId = $"las:workflow:{Guid.NewGuid().ToString().Replace("-", "")}";
             var executionId = $"las:workflow-execution:{Guid.NewGuid().ToString().Replace("-", "")}";

--- a/Test/Test.cs
+++ b/Test/Test.cs
@@ -13,6 +13,7 @@ using Moq.Protected;
 using Lucidtech.Las;
 using Lucidtech.Las.Core;
 using Lucidtech.Las.Utils;
+using Test.Service;
 
 namespace Test
 {
@@ -87,8 +88,7 @@ namespace Test
 
         [Test]
         public void TestGetAssetById() {
-            var assetId = $"las:asset:{Guid.NewGuid().ToString().Replace("-", "")}";
-            var response = Toby.GetAsset(assetId);
+            var response = Toby.GetAsset(Util.ResourceId("asset"));
             var expectedKeys = new [] {"assetId", "content"};
             CheckKeys(expectedKeys, response);
         }
@@ -96,9 +96,8 @@ namespace Test
         [TestCase("name", "description")]
         [TestCase("", "")]
         public void TestUpdateAsset(string? name, string? description) {
-            var assetId = $"las:asset:{Guid.NewGuid().ToString().Replace("-", "")}";
             var content = BitConverter.GetBytes(123456);
-            var response = Toby.UpdateAsset(assetId, content, new Dictionary<string?, string?>{
+            var response = Toby.UpdateAsset(Util.ResourceId("asset"), content, new Dictionary<string?, string?>{
                 {"name", name},
                 {"description", description}
             });
@@ -109,8 +108,7 @@ namespace Test
         [Ignore("delete endpoints doesn't work")]
         [Test]
         public void TestDeleteAsset() {
-            var assetId = $"las:asset:{Guid.NewGuid().ToString().Replace("-", "")}";
-            var response = Toby.DeleteAsset(assetId);
+            var response = Toby.DeleteAsset(Util.ResourceId("asset"));
             CheckKeys(new [] {"assetId", "name", "description"}, response);
         }
 
@@ -252,13 +250,12 @@ namespace Test
         [TestCase("foo", "bar", "name", "description")]
         [TestCase("foo", "bar", "name", "")]
         public void TestUpdateSecret(string username, string password, string? name = null, string? description = null) {
-            var secretId = $"las:model:{Guid.NewGuid().ToString().Replace("-", "")}";
             var data = new Dictionary<string, string>() {
                 {"username", username},
                 {"password", password}
             };
             var expectedKeys = new [] {"secretId"};
-            var response = Toby.UpdateSecret(secretId, data, new Dictionary<string, string?>{
+            var response = Toby.UpdateSecret(Util.ResourceId("secret"), data, new Dictionary<string, string?>{
                 {"name", name},
                 {"description", description}
             });
@@ -268,8 +265,7 @@ namespace Test
         [Ignore("delete endpoints doesn't work")]
         [Test]
         public void TestDeleteSecret() {
-            var secretId = $"las:secret:{Guid.NewGuid().ToString().Replace("-", "")}";
-            var response = Toby.DeleteSecret(secretId);
+            var response = Toby.DeleteSecret(Util.ResourceId("secret"));
             CheckKeys(new [] {"secretId", "name", "description"}, response);
         }
 
@@ -312,23 +308,21 @@ namespace Test
 
         [Test]
         public void TestGetTransition() {
-            var transitionId = $"las:transition:{Guid.NewGuid().ToString().Replace("-", "")}";
-            var response = Toby.GetTransition(transitionId);
+            var response = Toby.GetTransition(Util.ResourceId("transition"));
             CheckKeys(new [] {"transitionId", "name", "description", "transitionType"}, response);
         }
 
         [Ignore("delete endpoints doesn't work")]
         [Test]
         public void TestDeleteTransition() {
-            var transitionId = $"las:transition:{Guid.NewGuid().ToString().Replace("-", "")}";
-            var response = Toby.DeleteTransition(transitionId);
+            var response = Toby.DeleteTransition(Util.ResourceId("transition"));
             CheckKeys(new [] {"transitionId", "name", "description", "transitionType"}, response);
         }
 
         [TestCase("foo", "bar")]
         [TestCase(null, null)]
         public void TestUpdateTransition(string? name, string? description) {
-            
+
             var schema = new Dictionary<string, string>() {
                 {"schema", "https://json-schema.org/draft-04/schema#"},
                 {"title", "response"}
@@ -336,23 +330,22 @@ namespace Test
             var inputSchema = schema;
             var outputSchema = schema;
             var assets = new Dictionary<string, string?>{
-                {"foo", $"las:asset:{Guid.NewGuid().ToString().Replace("-", "")}"},
-                {"bar",  $"las:asset:{Guid.NewGuid().ToString().Replace("-", "")}"}
+                {"foo", Util.ResourceId("asset")},
+                {"bar", Util.ResourceId("asset")}
             };
             var environment = new Dictionary<string, string?>{
                 {"FOO", "FOO"},
                 {"BAR", "BAR"}
             };
-            var environmentSecrets = new List<string>{ $"las:secret:{Guid.NewGuid().ToString().Replace("-", "")}" };
-            var transitionId = $"las:transition:{Guid.NewGuid().ToString().Replace("-", "")}";
+            var environmentSecrets = new List<string>{ Util.ResourceId("secret")};
             var parameters = new Dictionary<string, string?>{
                 {"name", name},
                 {"description", description}
             };
             var response = Toby.UpdateTransition(
-                transitionId, 
-                inputSchema, 
-                outputSchema, 
+                Util.ResourceId("transition"),
+                inputSchema,
+                outputSchema,
                 assets,
                 environment,
                 environmentSecrets,
@@ -361,22 +354,18 @@ namespace Test
         }
 
         public void TestGetTransitionExecution() {
-            var executionId = $"las:transition-execution:{Guid.NewGuid().ToString().Replace("-", "")}";
-            var transitionId = $"las:transition:{Guid.NewGuid().ToString().Replace("-", "")}";
-            var response = Toby.GetTransitionExecution(transitionId, executionId);
+            var response = Toby.GetTransitionExecution(Util.ResourceId("transition"), Util.ResourceId("transition-execution"));
             CheckKeys(new [] {"transitionId", "executionId", "status"}, response);
         }
 
         [Test]
         public void TestExecuteTransition() {
-            var transitionId = $"las:transition:{Guid.NewGuid().ToString().Replace("-", "")}";
-            var response = Toby.ExecuteTransition(transitionId);
+            var response = Toby.ExecuteTransition(Util.ResourceId("transition"));
             CheckKeys(new [] {"transitionId", "executionId", "status"}, response);
         }
 
         [TestCase(
             "running",
-            "las:transition-execution:08b49ae64cd746f384f05880ef5de72f",
             3,
             null,
             "startTime",
@@ -384,17 +373,16 @@ namespace Test
         )]
         public void TestListTransitionExecutions(
             string? status = null,
-            string? executionId = null,
             int? maxResults = null,
             string? nextToken = null,
             string? sortBy = null,
             string? order = null
         ) {
-            var transitionId = $"las:transition:{Guid.NewGuid().ToString().Replace("-", "")}";
+            var executionIds = new List<string>{ Util.ResourceId("transition-execution") };
             var response = Toby.ListTransitionExecutions(
-                transitionId,
+                Util.ResourceId("transition"),
                 status,
-                new List<string>{ executionId },
+                executionIds,
                 maxResults,
                 nextToken,
                 sortBy,
@@ -417,14 +405,13 @@ namespace Test
             string? sortBy = null,
             string? order = null
         ) {
-            var transitionId = $"las:transition:{Guid.NewGuid().ToString().Replace("-", "")}";
             var statuses = new List<string>{ "running", "succeeded" };
             var executionIds = new List<string>{
-                $"las:transition-execution:{Guid.NewGuid().ToString().Replace("-", "")}",
-                $"las:transition-execution:{Guid.NewGuid().ToString().Replace("-", "")}"
+                Util.ResourceId("transition-execution"),
+                Util.ResourceId("transition-execution")
             };
             var response = Toby.ListTransitionExecutions(
-                transitionId,
+                Util.ResourceId("transition"),
                 statuses,
                 executionIds,
                 maxResults,
@@ -448,11 +435,9 @@ namespace Test
             Dictionary<string, string>? error = null,
             DateTime? startTime = null
         ) {
-            var transitionId = $"las:transition:{Guid.NewGuid().ToString().Replace("-", "")}";
-            var executionId = $"las:transition-execution:{Guid.NewGuid().ToString().Replace("-", "")}";
             var response = Toby.UpdateTransitionExecution(
-                transitionId,
-                executionId,
+                Util.ResourceId("transition"),
+                Util.ResourceId("transition-execution"),
                 status,
                 output,
                 error,
@@ -472,9 +457,7 @@ namespace Test
 
         [Test]
         public void TestSendHeartbeat() {
-            var executionId= $"las:transition-execution:{Guid.NewGuid().ToString().Replace("-", "")}";
-            var transitionId = $"las:transition:{Guid.NewGuid().ToString().Replace("-", "")}";
-            var response = Toby.SendHeartbeat(transitionId, executionId);
+            var response = Toby.SendHeartbeat(Util.ResourceId("transition"), Util.ResourceId("transition-execution"));
             CheckKeys(new [] {"Your request executed successfully"}, response);
         }
 
@@ -494,27 +477,24 @@ namespace Test
 
         [Test]
         public void TestGetUser() {
-            var userId = $"las:user:{Guid.NewGuid().ToString().Replace("-", "")}";
-            var response = Toby.GetUser(userId);
+            var response = Toby.GetUser(Util.ResourceId("user"));
             CheckKeys(new [] {"userId", "email"}, response);
         }
 
         [TestCase(null, null)]
         [TestCase("name", "avatar")]
         public void TestUpdateUser(string? name, string? avatar) {
-            var userId = $"las:user:{Guid.NewGuid().ToString().Replace("-", "")}";
             var parameters = new Dictionary<string, object?>{
                 {"name", name},
                 {"avatar", avatar},
             };
-            var response = Toby.UpdateUser(userId, parameters);
+            var response = Toby.UpdateUser(Util.ResourceId("user"), parameters);
         }
 
         [Test]
         [Ignore("delete endpoints doesn't work")]
         public void TestDeleteUser() {
-            var userId = $"las:user:{Guid.NewGuid().ToString().Replace("-", "")}";
-            var response = Toby.DeleteUser(userId);
+            var response = Toby.DeleteUser(Util.ResourceId("user"));
             CheckKeys(new [] {"userId", "email"}, response);
         }
 
@@ -523,18 +503,17 @@ namespace Test
         [TestCase("name", "")]
         [TestCase(null, null)]
         public void TestCreateWorkflow(string name, string description) {
-            var secretId = $"las:secret:{Guid.NewGuid().ToString().Replace("-", "")}";
             var spec = new Dictionary<string, object>{
                 {"definition", new Dictionary<string, object>{
                     {"States", new Dictionary<string, string>()}
                 }}
             };
-            
-            var environmentSecrets = new List<string>{ secretId };
+
+            var environmentSecrets = new List<string>{ Util.ResourceId("secret") };
             var env = new Dictionary<string, string>{{"FOO", "BAR"}};
             var completedConfig = new Dictionary<string, object>{
                 {"imageUrl", "my/docker:image"},
-                {"secretId", secretId},
+                {"secretId", Util.ResourceId("secret")},
                 {"environment", env},
                 {"environmentSecrets", environmentSecrets}
             };
@@ -563,8 +542,7 @@ namespace Test
 
         [Test]
         public void TestGetWorkflow() {
-            var workflowId = $"las:workflow:{Guid.NewGuid().ToString().Replace("-", "")}";
-            var response = Toby.GetWorkflow(workflowId);
+            var response = Toby.GetWorkflow(Util.ResourceId("workflow"));
             CheckKeys(new [] {"workflowId", "name", "description"}, response);
         }
 
@@ -573,8 +551,7 @@ namespace Test
         [TestCase("name", "")]
         [TestCase(null, null)]
         public void TestUpdateWorkflow(string name, string description) {
-            var workflowId = $"las:workflow:{Guid.NewGuid().ToString().Replace("-", "")}";
-            var response = Toby.UpdateWorkflow(workflowId, new Dictionary<string, string?>{
+            var response = Toby.UpdateWorkflow(Util.ResourceId("workflow"), new Dictionary<string, string?>{
                 {"name", name},
                 {"description", description}
             });
@@ -584,16 +561,14 @@ namespace Test
         [Test]
         [Ignore("delete endpoints doesn't work")]
         public void TestDeleteWorkflow() {
-            var workflowId = $"las:workflow:{Guid.NewGuid().ToString().Replace("-", "")}";
-            var response = Toby.DeleteWorkflow(workflowId);
+            var response = Toby.DeleteWorkflow(Util.ResourceId("workflow"));
             CheckKeys(new [] {"workflowId", "name", "description"}, response);
         }
 
         [Test]
         public void TestExecuteWorkflow() {
-            var workflowId = $"las:workflow:{Guid.NewGuid().ToString().Replace("-", "")}";
             var content = new Dictionary<string, object>();
-            var response = Toby.ExecuteWorkflow(workflowId, content);
+            var response = Toby.ExecuteWorkflow(Util.ResourceId("workflow"), content);
             var expectedKeys = new [] {
                 "workflowId",
                 "executionId",
@@ -617,10 +592,9 @@ namespace Test
             string? sortBy = null,
             string? order = null
         ) {
-            var workflowId = $"las:workflow:{Guid.NewGuid().ToString().Replace("-", "")}";
             var statuses = new List<string>{ "running", "succeeded" };
             var response = Toby.ListWorkflowExecutions(
-                workflowId,
+                Util.ResourceId("workflow"),
                 statuses,
                 maxResults,
                 nextToken,
@@ -632,18 +606,13 @@ namespace Test
 
         [Test]
         public void TestGetWorkflowExecution() {
-            var executionId = $"las:workflow-execution:{Guid.NewGuid().ToString().Replace("-", "")}";
-            var workflowId = $"las:workflow:{Guid.NewGuid().ToString().Replace("-", "")}";
-            var response = Toby.GetWorkflowExecution(workflowId, executionId);
+            var response = Toby.GetWorkflowExecution(Util.ResourceId("workflow"), Util.ResourceId("workflow-execution"));
             CheckKeys(new [] {"workflowId", "executionId"}, response);
         }
 
         [Test]
         public void TestUpdateWorkflowExecution() {
-            var workflowId = $"las:workflow:{Guid.NewGuid().ToString().Replace("-", "")}";
-            var executionId = $"las:workflow-execution:{Guid.NewGuid().ToString().Replace("-", "")}";
-            var transitionId = $"las:transition:{Guid.NewGuid().ToString().Replace("-", "")}";
-            var response = Toby.UpdateWorkflowExecution(workflowId, executionId, transitionId);
+            var response = Toby.UpdateWorkflowExecution(Util.ResourceId("workflow"), Util.ResourceId("workflow-execution"), Util.ResourceId("transition"));
             var expectedKeys = new [] {
                 "workflowId",
                 "executionId",
@@ -653,13 +622,11 @@ namespace Test
             };
             CheckKeys(expectedKeys, response);
         }
-     
+
         [Test]
         [Ignore("delete endpoints doesn't work")]
         public void TestDeleteWorkflowExecution() {
-            var workflowId = $"las:workflow:{Guid.NewGuid().ToString().Replace("-", "")}";
-            var executionId = $"las:workflow-execution:{Guid.NewGuid().ToString().Replace("-", "")}";
-            var response = Toby.DeleteWorkflowExecution(workflowId, executionId);
+            var response = Toby.DeleteWorkflowExecution(Util.ResourceId("workflow"), Util.ResourceId("workflow-execution"));
             var expectedKeys = new [] {
                 "workflowId",
                 "executionId",

--- a/Test/Test.cs
+++ b/Test/Test.cs
@@ -236,6 +236,14 @@ namespace Test
             CheckKeys(Util.ExpectedKeys("batch"), response);
         }
 
+        [Ignore("delete endpoints doesn't work")]
+        [TestCase(true)]
+        [TestCase(false)]
+        public void TestDeleteBatch(bool deleteDocuments) {
+            var response = Toby.DeleteBatch(Util.ResourceId("batch"), deleteDocuments);
+            CheckKeys(Util.ExpectedKeys("batch"), response);
+        }
+        
         [Test]
         public void TestListLogs() {
             var response = Toby.ListLogs(

--- a/Test/Test.cs
+++ b/Test/Test.cs
@@ -236,6 +236,19 @@ namespace Test
             CheckKeys(Util.ExpectedKeys("batch"), response);
         }
 
+        [Test]
+        public void TestListLogs() {
+            var response = Toby.ListLogs(
+                transitionId: Util.ResourceId("transition"),
+                transitionExecutionId: Util.ResourceId("transition-execution"),
+                workflowId: Util.ResourceId("workflow"),
+                workflowExecutionId: Util.ResourceId("workflow-execution"),
+                maxResults: 100,
+                nextToken: "foo"
+            );
+            CheckKeys(Util.ExpectedKeys("logs"), response);
+        }
+
         [TestCase("foo", 3)]
         [TestCase(null, null)]
         public void TestListModels(string nextToken, int maxResults) {

--- a/Test/Test.cs
+++ b/Test/Test.cs
@@ -106,6 +106,14 @@ namespace Test
             CheckKeys(expectedKeys, response);
         }
 
+        [Ignore("delete endpoints doesn't work")]
+        [Test]
+        public void TestDeleteAsset() {
+            var assetId = $"las:asset:{Guid.NewGuid().ToString().Replace("-", "")}";
+            var response = Toby.DeleteAsset(assetId);
+            CheckKeys(new [] {"assetId", "name", "description"}, response);
+        }
+
         [Test]
         public void TestCreateDocument()
         {

--- a/Test/Test.cs
+++ b/Test/Test.cs
@@ -598,6 +598,22 @@ namespace Test
         }
 
         [Test]
+        public void TestUpdateWorkflowExecution() {
+            var workflowId = $"las:workflow:{Guid.NewGuid().ToString().Replace("-", "")}";
+            var executionId = $"las:workflow-execution:{Guid.NewGuid().ToString().Replace("-", "")}";
+            var transitionId = $"las:transition:{Guid.NewGuid().ToString().Replace("-", "")}";
+            var response = Toby.UpdateWorkflowExecution(workflowId, executionId, transitionId);
+            var expectedKeys = new [] {
+                "workflowId",
+                "executionId",
+                "startTime",
+                "endTime",
+                "transitionExecutions"
+            };
+            CheckKeys(expectedKeys, response);
+        }
+     
+        [Test]
         [Ignore("delete endpoints doesn't work")]
         public void TestDeleteWorkflowExecution() {
             var workflowId = $"las:workflow:{Guid.NewGuid().ToString().Replace("-", "")}";

--- a/Test/Test.cs
+++ b/Test/Test.cs
@@ -481,24 +481,11 @@ namespace Test
                     {"States", new Dictionary<string, string>()}
                 }}
             };
-
-            var environmentSecrets = new List<string>{ Util.ResourceId("secret") };
-            var env = new Dictionary<string, string>{{"FOO", "BAR"}};
-            var completedConfig = new Dictionary<string, object>{
-                {"imageUrl", "my/docker:image"},
-                {"secretId", Util.ResourceId("secret")},
-                {"environment", env},
-                {"environmentSecrets", environmentSecrets}
-            };
-            var errorConfig = new Dictionary<string, object>{
-                {"email", "foo@lucid.com"},
-                {"manualRetry", true}
-            };
             var parameters = new Dictionary<string, string?>{
                 {"name", name},
                 {"description", description}
             };
-            var response = Toby.CreateWorkflow(spec, errorConfig, completedConfig, parameters);
+            var response = Toby.CreateWorkflow(spec, Util.ErrorConfig(), Util.CompletedConfig(), parameters);
             CheckKeys(Util.ExpectedKeys("workflow"), response);
         }
 

--- a/Test/Test.cs
+++ b/Test/Test.cs
@@ -404,15 +404,16 @@ namespace Test
         }
 
         static object[] UpdateTransitionExecutionSources = {
-            new object[] { "succeeded", new Dictionary<string, string>{{"foo", "bar"}}, null },
-            new object[] { "failed", null, new Dictionary<string, string>{{"message", "foobar"}} }
+            new object[] { "succeeded", new Dictionary<string, string>{{"foo", "bar"}}, null, new DateTime(2016, 12, 31, 5, 10, 20, DateTimeKind.Utc)},
+            new object[] { "failed", null, new Dictionary<string, string>{{"message", "foobar"}}, null }
         };
 
         [Test, TestCaseSource("UpdateTransitionExecutionSources")]
         public void TestUpdateTransitionExecution(
             string status,
             Dictionary<string, string>? output = null,
-            Dictionary<string, string>? error = null
+            Dictionary<string, string>? error = null,
+            DateTime? startTime = null
         ) {
             var transitionId = $"las:transition:{Guid.NewGuid().ToString().Replace("-", "")}";
             var executionId = $"las:transition-execution:{Guid.NewGuid().ToString().Replace("-", "")}";
@@ -422,7 +423,7 @@ namespace Test
                 status,
                 output,
                 error,
-                startTime: "2021-02-25 10:00:34.263905"
+                startTime 
             );
             CheckKeys(new [] {
                 "completedBy",

--- a/Test/Test.cs
+++ b/Test/Test.cs
@@ -265,6 +265,14 @@ namespace Test
             CheckKeys(expectedKeys, response);
         }
 
+        [Ignore("delete endpoints doesn't work")]
+        [Test]
+        public void TestDeleteSecret() {
+            var secretId = $"las:secret:{Guid.NewGuid().ToString().Replace("-", "")}";
+            var response = Toby.DeleteSecret(secretId);
+            CheckKeys(new [] {"secretId", "name", "description"}, response);
+        }
+
         [TestCase("docker", "name", "description")]
         [TestCase("manual", "name", "description")]
         [TestCase("docker", null, null)]

--- a/Test/Test.cs
+++ b/Test/Test.cs
@@ -219,7 +219,12 @@ namespace Test
         [Ignore("delete endpoints doesn't work")]
         [TestCase(2, "foo", "las:consent:3ac6c39a3f9948a3b1aeb23ae7c73291")]
         public void TestDeleteDocuments(int maxResults, string nextToken, string consentId) {
-            var response = Toby.DeleteDocuments(maxResults: maxResults, nextToken: nextToken, consentId: consentId);
+            var response = Toby.DeleteDocuments(
+                maxResults: maxResults, 
+                nextToken: nextToken, 
+                consentId: consentId,
+                batchId: Util.ResourceId("batch")
+            );
             CheckKeys(Util.ExpectedKeys("documents"), response);
         }
 

--- a/Test/Test.cs
+++ b/Test/Test.cs
@@ -44,7 +44,12 @@ namespace Test
                 .Protected()
                 .Setup("CommonConstructor");
 
-            Toby = new Client(mockCreds.Object);
+            if (Environment.GetEnvironmentVariable("CREDENTIALS") == "FROM_FILE"){
+                Toby = new Client();
+            }
+            else {
+                Toby = new Client(mockCreds.Object);
+            }
         }
 
         [SetUp]

--- a/Test/Test.cs
+++ b/Test/Test.cs
@@ -17,7 +17,7 @@ using Lucidtech.Las.Utils;
 namespace Test
 {
     [TestFixture]
-    public class TestClient 
+    public class TestClient
     {
         private Client Toby { get; set; }
         private Dictionary<string, object> CreateDocResponse { get; set; }
@@ -120,7 +120,7 @@ namespace Test
         [TestCase("foo", 2, "las:consent:08b49ae64cd746f384f05880ef5de72f", null)]
         public void TestListDocuments(string nextToken, int maxResults, string consentId, string batchId) {
             var response = Toby.ListDocuments(
-                nextToken: nextToken, 
+                nextToken: nextToken,
                 maxResults: maxResults,
                 consentId: consentId,
                 batchId: batchId
@@ -256,7 +256,7 @@ namespace Test
             });
             CheckKeys(expectedKeys, response);
         }
-        
+
         [TestCase("docker", "name", "description")]
         [TestCase("manual", "name", "description")]
         [TestCase("docker", null, null)]
@@ -423,7 +423,7 @@ namespace Test
                 status,
                 output,
                 error,
-                startTime 
+                startTime
             );
             CheckKeys(new [] {
                 "completedBy",
@@ -490,19 +490,30 @@ namespace Test
         [TestCase("name", "")]
         [TestCase(null, null)]
         public void TestCreateWorkflow(string name, string description) {
+            var secretId = $"las:secret:{Guid.NewGuid().ToString().Replace("-", "")}";
             var spec = new Dictionary<string, object>{
                 {"definition", new Dictionary<string, object>{
                     {"States", new Dictionary<string, string>()}
                 }}
             };
-            var errorConfig = new Dictionary<string, string>{
-                {"email", "foo@lucid.com"}
+            
+            var environmentSecrets = new List<string>{ secretId };
+            var env = new Dictionary<string, string>{{"FOO", "BAR"}};
+            var completedConfig = new Dictionary<string, object>{
+                {"imageUrl", "my/docker:image"},
+                {"secretId", secretId},
+                {"environment", env},
+                {"environmentSecrets", environmentSecrets}
+            };
+            var errorConfig = new Dictionary<string, object>{
+                {"email", "foo@lucid.com"},
+                {"manualRetry", true}
             };
             var parameters = new Dictionary<string, string?>{
                 {"name", name},
                 {"description", description}
             };
-            var response = Toby.CreateWorkflow(spec, errorConfig, parameters);
+            var response = Toby.CreateWorkflow(spec, errorConfig, completedConfig, parameters);
             CheckKeys(new [] {"workflowId", "name", "description"}, response);
         }
 
@@ -603,16 +614,16 @@ namespace Test
         }
     }
 
-    public static class Example 
+    public static class Example
     {
         public static string ConsentId() { return "las:consent:abc123def456abc123def456abc123de"; }
         public static string ContentType() { return "image/jpeg"; }
         public static string Description() { return "This is my new batch for receipts july 2020"; }
         public static string ModelId() { return "las:model:abc123def456abc123def456abc123de"; }
         public static string DocPath() { return Environment.ExpandEnvironmentVariables("Test/Files/example.jpeg"); }
-        public static Credentials Creds() 
+        public static Credentials Creds()
         {
-            return new Credentials("foo", "bar", "baz", "baaz", "http://127.0.0.1:4010"); 
+            return new Credentials("foo", "bar", "baz", "baaz", "http://127.0.0.1:4010");
         }
     }
 }

--- a/Test/Test.cs
+++ b/Test/Test.cs
@@ -75,22 +75,21 @@ namespace Test
                 {"description", description}
             };
             var response = Toby.CreateAsset(bytes, parameters);
-            CheckKeys(new [] {"assetId"}, response);
+            CheckKeys(Util.ExpectedKeys("asset"), response);
         }
 
         [TestCase("foo", 3)]
         [TestCase(null, null)]
         public void TestListAssets(string nextToken, int maxResults) {
             var response = Toby.ListAssets(nextToken: nextToken, maxResults: maxResults);
-            CheckKeys(new [] {"nextToken", "assets"}, response);
+            CheckKeys(Util.ExpectedKeys("assets"), response);
         }
 
 
         [Test]
         public void TestGetAssetById() {
             var response = Toby.GetAsset(Util.ResourceId("asset"));
-            var expectedKeys = new [] {"assetId", "content"};
-            CheckKeys(expectedKeys, response);
+            CheckKeys(Util.ExpectedKeys("asset"), response);
         }
 
         [TestCase("name", "description")]
@@ -101,22 +100,20 @@ namespace Test
                 {"name", name},
                 {"description", description}
             });
-            var expectedKeys = new [] {"assetId"};
-            CheckKeys(expectedKeys, response);
+            CheckKeys(Util.ExpectedKeys("asset"), response);
         }
 
         [Ignore("delete endpoints doesn't work")]
         [Test]
         public void TestDeleteAsset() {
             var response = Toby.DeleteAsset(Util.ResourceId("asset"));
-            CheckKeys(new [] {"assetId", "name", "description"}, response);
+            CheckKeys(Util.ExpectedKeys("asset"), response);
         }
 
         [Test]
         public void TestCreateDocument()
         {
-            var expectedKeys = new [] {"documentId", "contentType", "consentId"};
-            CheckKeys(expectedKeys, CreateDocResponse);
+            CheckKeys(Util.ExpectedKeys("document"), CreateDocResponse);
         }
 
         [TestCase("foo", 3, null, null)]
@@ -131,8 +128,7 @@ namespace Test
                 consentId: consentId,
                 batchId: batchId
             );
-            var expectedKeys = new [] {"documents"};
-            CheckKeys(expectedKeys, response);
+            CheckKeys(Util.ExpectedKeys("documents"), response);
         }
 
         [TestCase("HIGH")]
@@ -145,8 +141,7 @@ namespace Test
                 Example.ModelId(),
                 imageQuality: imageQuality
             );
-            var expectedKeys = new [] {"documentId", "predictions"};
-            CheckKeys(expectedKeys, response);
+            CheckKeys(Util.ExpectedKeys("prediction"), response);
         }
 
         [Test]
@@ -157,8 +152,7 @@ namespace Test
                 Example.ModelId(),
                 maxPages: 2
             );
-            var expectedKeys = new [] {"documentId", "predictions"};
-            CheckKeys(expectedKeys, response);
+            CheckKeys(Util.ExpectedKeys("prediction"), response);
         }
 
         [Test]
@@ -169,16 +163,14 @@ namespace Test
                 Example.ModelId(),
                 autoRotate: true
             );
-            var expectedKeys = new [] {"documentId", "predictions"};
-            CheckKeys(expectedKeys, response);
+            CheckKeys(Util.ExpectedKeys("prediction"), response);
         }
 
         [Test]
         public void TestGetDocument()
         {
             var response = Toby.GetDocument((string)CreateDocResponse["documentId"]);
-            var expectedKeys = new [] {"documentId", "contentType", "consentId"};
-            CheckKeys(expectedKeys, response);
+            CheckKeys(Util.ExpectedKeys("document"), response);
         }
 
         [TestCase("54.50", "2007-07-30")]
@@ -190,16 +182,14 @@ namespace Test
                 new Dictionary<string, string>(){{"label", "purchase_date"},{"value", purchase_date}}
             };
             var response = Toby.UpdateDocument((string)CreateDocResponse["documentId"], ground_truth);
-            var expectedKeys = new [] {"documentId", "consentId", "contentType", "groundTruth"};
-            CheckKeys(expectedKeys, response);
+            CheckKeys(Util.ExpectedKeys("document"), response);
         }
 
         [Ignore("delete endpoints doesn't work")]
         [TestCase(2, "foo", "las:consent:3ac6c39a3f9948a3b1aeb23ae7c73291")]
         public void TestDeleteDocuments(int maxResults, string nextToken, string consentId) {
             var response = Toby.DeleteDocuments(maxResults: maxResults, nextToken: nextToken, consentId: consentId);
-            var expectedKeys = new [] {"documents"};
-            CheckKeys(expectedKeys, response);
+            CheckKeys(Util.ExpectedKeys("documents"), response);
         }
 
         [TestCase(null, null)]
@@ -207,16 +197,14 @@ namespace Test
         public void TestCreateBatch(string? name, string? description)
         {
             var response = Toby.CreateBatch(Example.Description());
-            var expectedKeys = new [] {"name", "description", "batchId"};
-            CheckKeys(expectedKeys, response);
+            CheckKeys(Util.ExpectedKeys("batch"), response);
         }
 
         [TestCase("foo", 3)]
         [TestCase(null, null)]
         public void TestListModels(string nextToken, int maxResults) {
             var response = Toby.ListModels(nextToken: nextToken, maxResults: maxResults);
-            var expectedKeys = new [] {"models"};
-            CheckKeys(expectedKeys, response);
+            CheckKeys(Util.ExpectedKeys("models"), response);
         }
 
 
@@ -224,8 +212,7 @@ namespace Test
         [TestCase(null, null)]
         public void TestListPredictions(string nextToken, int maxResults) {
             var response = Toby.ListPredictions(nextToken: nextToken, maxResults: maxResults);
-            var expectedKeys = new [] {"predictions"};
-            CheckKeys(expectedKeys, response);
+            CheckKeys(Util.ExpectedKeys("predictions"), response);
         }
 
         [TestCase("foo", "bar")]
@@ -235,16 +222,14 @@ namespace Test
                 {"password", password}
             };
             var response = Toby.CreateSecret(data);
-            var expectedKeys = new [] {"secretId"};
-            CheckKeys(expectedKeys, response);
+            CheckKeys(Util.ExpectedKeys("secret"), response);
         }
 
         [TestCase("foo", 3)]
         [TestCase(null, null)]
         public void TestListSecrets(string nextToken, int maxResults) {
             var response = Toby.ListSecrets(nextToken: nextToken, maxResults: maxResults);
-            var expectedKeys = new [] {"secrets"};
-            CheckKeys(expectedKeys, response);
+            CheckKeys(Util.ExpectedKeys("secrets"), response);
         }
 
         [TestCase("foo", "bar", "name", "description")]
@@ -254,19 +239,18 @@ namespace Test
                 {"username", username},
                 {"password", password}
             };
-            var expectedKeys = new [] {"secretId"};
             var response = Toby.UpdateSecret(Util.ResourceId("secret"), data, new Dictionary<string, string?>{
                 {"name", name},
                 {"description", description}
             });
-            CheckKeys(expectedKeys, response);
+            CheckKeys(Util.ExpectedKeys("secret"), response);
         }
 
         [Ignore("delete endpoints doesn't work")]
         [Test]
         public void TestDeleteSecret() {
             var response = Toby.DeleteSecret(Util.ResourceId("secret"));
-            CheckKeys(new [] {"secretId", "name", "description"}, response);
+            CheckKeys(Util.ExpectedKeys("secret"), response);
         }
 
         [TestCase("docker", "name", "description")]
@@ -295,7 +279,7 @@ namespace Test
             }
 
             var response = Toby.CreateTransition(transitionType, inputSchema, outputSchema, parameters, attributes);
-            CheckKeys(new [] {"name", "transitionId", "transitionType"}, response);
+            CheckKeys(Util.ExpectedKeys("transition"), response);
         }
 
         [TestCase("docker")]
@@ -303,20 +287,20 @@ namespace Test
         [TestCase(null)]
         public void TestListTransitions(string? transitionType) {
             var response = Toby.ListTransitions(transitionType);
-            CheckKeys(new [] {"transitions"}, response);
+            CheckKeys(Util.ExpectedKeys("transitions"), response);
         }
 
         [Test]
         public void TestGetTransition() {
             var response = Toby.GetTransition(Util.ResourceId("transition"));
-            CheckKeys(new [] {"transitionId", "name", "description", "transitionType"}, response);
+            CheckKeys(Util.ExpectedKeys("transition"), response);
         }
 
         [Ignore("delete endpoints doesn't work")]
         [Test]
         public void TestDeleteTransition() {
             var response = Toby.DeleteTransition(Util.ResourceId("transition"));
-            CheckKeys(new [] {"transitionId", "name", "description", "transitionType"}, response);
+            CheckKeys(Util.ExpectedKeys("transition"), response);
         }
 
         [TestCase("foo", "bar")]
@@ -350,18 +334,18 @@ namespace Test
                 environment,
                 environmentSecrets,
                 parameters);
-            CheckKeys(new [] {"transitionId", "name", "description", "transitionType"}, response);
+            CheckKeys(Util.ExpectedKeys("transition"), response);
         }
 
         public void TestGetTransitionExecution() {
             var response = Toby.GetTransitionExecution(Util.ResourceId("transition"), Util.ResourceId("transition-execution"));
-            CheckKeys(new [] {"transitionId", "executionId", "status"}, response);
+            CheckKeys(Util.ExpectedKeys("transition-execution"), response);
         }
 
         [Test]
         public void TestExecuteTransition() {
             var response = Toby.ExecuteTransition(Util.ResourceId("transition"));
-            CheckKeys(new [] {"transitionId", "executionId", "status"}, response);
+            CheckKeys(Util.ExpectedKeys("transition-execution"), response);
         }
 
         [TestCase(
@@ -388,8 +372,7 @@ namespace Test
                 sortBy,
                 order
             );
-            var expectedKeys = new [] {"executions"};
-            CheckKeys(expectedKeys, response);
+            CheckKeys(Util.ExpectedKeys("transition-executions"), response);
         }
 
         [Ignore("multivalue query parameters don't work with prism")]
@@ -419,8 +402,7 @@ namespace Test
                 sortBy,
                 order
             );
-            var expectedKeys = new [] {"executions"};
-            CheckKeys(expectedKeys, response);
+            CheckKeys(Util.ExpectedKeys("transition-executions"), response);
         }
 
         static object[] UpdateTransitionExecutionSources = {
@@ -443,42 +425,33 @@ namespace Test
                 error,
                 startTime
             );
-            CheckKeys(new [] {
-                "completedBy",
-                "endTime",
-                "executionId",
-                "input",
-                "logId",
-                "startTime",
-                "status",
-                "transitionId"
-            }, response);
+            CheckKeys(Util.ExpectedKeys("transition-execution"), response);
         }
 
         [Test]
         public void TestSendHeartbeat() {
             var response = Toby.SendHeartbeat(Util.ResourceId("transition"), Util.ResourceId("transition-execution"));
-            CheckKeys(new [] {"Your request executed successfully"}, response);
+            CheckKeys(Util.ExpectedKeys("heartbeats"), response);
         }
 
         [Ignore("")]
         [TestCase("foo@bar.com")]
         public void TestCreateUser(string email) {
             var response = Toby.CreateUser(email);
-            CheckKeys(new [] {"email", "userId"}, response);
+            CheckKeys(Util.ExpectedKeys("user"), response);
         }
 
         [TestCase("foo", 3)]
         [TestCase(null, null)]
         public void TestListUsers(string nextToken, int maxResults) {
             var response = Toby.ListUsers(nextToken: nextToken, maxResults: maxResults);
-            CheckKeys(new [] {"nextToken", "users"}, response);
+            CheckKeys(Util.ExpectedKeys("users"), response);
         }
 
         [Test]
         public void TestGetUser() {
             var response = Toby.GetUser(Util.ResourceId("user"));
-            CheckKeys(new [] {"userId", "email"}, response);
+            CheckKeys(Util.ExpectedKeys("user"), response);
         }
 
         [TestCase(null, null)]
@@ -495,7 +468,7 @@ namespace Test
         [Ignore("delete endpoints doesn't work")]
         public void TestDeleteUser() {
             var response = Toby.DeleteUser(Util.ResourceId("user"));
-            CheckKeys(new [] {"userId", "email"}, response);
+            CheckKeys(Util.ExpectedKeys("user"), response);
         }
 
         [TestCase("name", "description")]
@@ -526,7 +499,7 @@ namespace Test
                 {"description", description}
             };
             var response = Toby.CreateWorkflow(spec, errorConfig, completedConfig, parameters);
-            CheckKeys(new [] {"workflowId", "name", "description"}, response);
+            CheckKeys(Util.ExpectedKeys("workflow"), response);
         }
 
         [TestCase(100, "foo")]
@@ -537,13 +510,13 @@ namespace Test
             string? nextToken = null
         ) {
             var response = Toby.ListWorkflows(maxResults, nextToken);
-            CheckKeys(new [] {"workflows"}, response);
+            CheckKeys(Util.ExpectedKeys("workflows"), response);
         }
 
         [Test]
         public void TestGetWorkflow() {
             var response = Toby.GetWorkflow(Util.ResourceId("workflow"));
-            CheckKeys(new [] {"workflowId", "name", "description"}, response);
+            CheckKeys(Util.ExpectedKeys("workflow"), response);
         }
 
         [TestCase("name", "description")]
@@ -555,28 +528,21 @@ namespace Test
                 {"name", name},
                 {"description", description}
             });
-            CheckKeys(new [] {"workflowId", "name", "description"}, response);
+            CheckKeys(Util.ExpectedKeys("workflow"), response);
         }
 
         [Test]
         [Ignore("delete endpoints doesn't work")]
         public void TestDeleteWorkflow() {
             var response = Toby.DeleteWorkflow(Util.ResourceId("workflow"));
-            CheckKeys(new [] {"workflowId", "name", "description"}, response);
+            CheckKeys(Util.ExpectedKeys("workflow"), response);
         }
 
         [Test]
         public void TestExecuteWorkflow() {
             var content = new Dictionary<string, object>();
             var response = Toby.ExecuteWorkflow(Util.ResourceId("workflow"), content);
-            var expectedKeys = new [] {
-                "workflowId",
-                "executionId",
-                "startTime",
-                "endTime",
-                "transitionExecutions"
-            };
-            CheckKeys(expectedKeys, response);
+            CheckKeys(Util.ExpectedKeys("workflow-execution"), response);
         }
 
         [Ignore("multivalue query parameters don't work with prism")]
@@ -601,40 +567,26 @@ namespace Test
                 sortBy,
                 order
             );
-            CheckKeys(new [] {"workflowId", "executions"}, response);
+            CheckKeys(Util.ExpectedKeys("workflow-executions"), response);
         }
 
         [Test]
         public void TestGetWorkflowExecution() {
             var response = Toby.GetWorkflowExecution(Util.ResourceId("workflow"), Util.ResourceId("workflow-execution"));
-            CheckKeys(new [] {"workflowId", "executionId"}, response);
+            CheckKeys(Util.ExpectedKeys("workflow-execution"), response);
         }
 
         [Test]
         public void TestUpdateWorkflowExecution() {
             var response = Toby.UpdateWorkflowExecution(Util.ResourceId("workflow"), Util.ResourceId("workflow-execution"), Util.ResourceId("transition"));
-            var expectedKeys = new [] {
-                "workflowId",
-                "executionId",
-                "startTime",
-                "endTime",
-                "transitionExecutions"
-            };
-            CheckKeys(expectedKeys, response);
+            CheckKeys(Util.ExpectedKeys("workflow-execution"), response);
         }
 
         [Test]
         [Ignore("delete endpoints doesn't work")]
         public void TestDeleteWorkflowExecution() {
             var response = Toby.DeleteWorkflowExecution(Util.ResourceId("workflow"), Util.ResourceId("workflow-execution"));
-            var expectedKeys = new [] {
-                "workflowId",
-                "executionId",
-                "startTime",
-                "endTime",
-                "transitionExecutions"
-            };
-            CheckKeys(expectedKeys, response);
+            CheckKeys(Util.ExpectedKeys("workflow-execution"), response);
         }
     }
 

--- a/Test/Test.cs
+++ b/Test/Test.cs
@@ -64,6 +64,37 @@ namespace Test
             );
             CreateDocResponse = JsonSerialPublisher.ObjectToDict<Dictionary<string, object>>(response);
         }
+        
+        [TestCase("name", "description", true)]
+        [TestCase("", "", false)]
+        [TestCase(null, null, false)]
+        public void TestCreateAppClient(string? name, string? description, bool generateSecret ) {
+            var parameters = new Dictionary<string, string?>{
+                {"name", name},
+                {"description", description}
+            };
+            var response = Toby.CreateAppClient(
+                attributes: parameters, 
+                generateSecret: generateSecret,
+                logoutUrls: new List<string>{"https://localhost/logout:3030"},
+                callbackUrls: new List<string>{"https://localhost/callback:3030"}
+            );
+            CheckKeys(Util.ExpectedKeys("appClient"), response);
+        }
+
+        [TestCase("foo", 3)]
+        [TestCase(null, null)]
+        public void TestListAppClients(string nextToken, int maxResults) {
+            var response = Toby.ListAppClients(nextToken: nextToken, maxResults: maxResults);
+            CheckKeys(Util.ExpectedKeys("appClients"), response);
+        }
+
+        [Ignore("delete endpoints doesn't work")]
+        [Test]
+        public void TestDeleteAppClient() {
+            var response = Toby.DeleteAppClient(Util.ResourceId("app-client"));
+            CheckKeys(Util.ExpectedKeys("appClient"), response);
+        }
 
         [TestCase("name", "description")]
         [TestCase("", "")]

--- a/Test/Test.csproj
+++ b/Test/Test.csproj
@@ -37,6 +37,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Test.cs" />
+    <Compile Include="Service.cs" />
     <!-- Uncomment the lines below when debugging
     -->
     <Compile Include="..\Lucidtech\Las\*" />


### PR DESCRIPTION
Full change log:
- startTime argument in PATCH /transitions/:id/executions/:id can be supplied as datetime object.
- PATCH /workflows/:id/executions/:id
- GET /workflows/:id/executions/:id
- DELETE /assets/:id
- DELETE /secrets/:id
- Update POST /workflows to include completedConfig, and support manualRetry in errorConfig
- Update PATCH /transitions/:id to include assets, environment, environmentSecrets
- Update PATCH /workflows/:id to include completedConfig, and errorConfig
- POST /appClients
- GET /appClients
- DELETE /appClients/:id
- GET /logs
- DELETE /batches/:id
- DELETE /documents:id?batchId=...