### PR TITLE
latest API changes

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -1,0 +1,24 @@
+name: dotnet package
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        dotnet-version: ['3.0', '3.1.x', '5.0.x' ]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup .NET Core SDK ${{ matrix.dotnet-version }}
+        uses: actions/setup-dotnet@v1.7.2
+        with:
+          dotnet-version: ${{ matrix.dotnet-version }}
+      - name: Install dependencies
+        run: dotnet restore
+      - name: Build
+        run: dotnet build --configuration Release --no-restore
+      - name: Test
+        run: dotnet test --no-restore --verbosity normal

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -20,3 +20,4 @@ jobs:
         run: make prism-start
       - name: Run Tests
         run: make test
+        

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        dotnet-version: ['3.0', '3.1.x', '5.0.x' ]
+        dotnet-version: ['4.6.1', '4.7.x']
 
     steps:
       - uses: actions/checkout@v2
@@ -17,8 +17,8 @@ jobs:
         with:
           dotnet-version: ${{ matrix.dotnet-version }}
       - name: Install dependencies
-        run: dotnet restore
+        run: dotnet restore Test
       - name: Build
-        run: dotnet build --configuration Release --no-restore
+        run: dotnet build --configuration Release --no-restore Test
       - name: Test
-        run: dotnet test --no-restore --verbosity normal
+        run: dotnet test --no-restore --verbosity normal Test

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -16,11 +16,7 @@ jobs:
         uses: actions/setup-dotnet@v1.7.2
         with:
           dotnet-version: ${{ matrix.dotnet-version }}
-      - name: Install dependencies
-        run: dotnet restore Test
-      - name: Build
-        run: dotnet build --configuration Release --no-restore Test
       - name: Setup Prism
         run: make prism-start
-      - name: Test
+      - name: Run Tests
         run: make test

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -1,4 +1,4 @@
-name: dotnet package
+name: Unit Tests
 
 on: [push]
 
@@ -21,4 +21,4 @@ jobs:
       - name: Build
         run: dotnet build --configuration Release --no-restore Test
       - name: Test
-        run: dotnet test --no-restore --verbosity normal Test
+        run: make test

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        dotnet-version: ['4.6.1', '4.7.x']
+        dotnet-version: ['3.0', '3.1.x', '5.0.x']
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        dotnet-version: ['3.0', '3.1.x', '5.0.x']
+        dotnet-version: ['5.0.x']
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -20,5 +20,7 @@ jobs:
         run: dotnet restore Test
       - name: Build
         run: dotnet build --configuration Release --no-restore Test
+      - name: Setup Prism
+        run: make prism-start
       - name: Test
         run: make test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog 
 
+## Version 1.5.0 - 2021-07-01
+
+- Added DeleteDocument
+- Added optional parameter datasetId to UpdateDocument
+- Added parameter deleteAll to DeleteDocuments
+- Added CreateDataBundle
+- Added ListDataBundles 
+- Added UpdateDataBundle
+- Added DeleteDataBundle
+
 ## Version 1.4.1 - 2021-07-01
 
 - Revert argument order for CreateDocuments, ListDocuments, and DeleteDocuments to avoid breaking changes.

--- a/Lucidtech/Las/Client.cs
+++ b/Lucidtech/Las/Client.cs
@@ -381,32 +381,30 @@ namespace Lucidtech.Las
         /// Update ground truth of the document, calls the POST /documents/{documentId} endpoint.
         /// This enables the API to learn from past mistakes.
         /// </summary>
-        /// <example>
-        /// <code>
-        /// Client client = new Client();
-        /// var groundTruth = new List&lt;Dictionary&lt;string, string&gt;&gt;()
-        /// {
-        ///     new Dictionary&lt;string, string&gt;() {{"label", "total_amount"},{"value", "54.50"}},
-        ///     new Dictionary&lt;string, string&gt;() {{"label", "purchase_date"},{"value", "2007-07-30"}}
-        /// };
-        /// var response = client.UpdateDocument('&lt;documentId&gt;', groundTruth);
-        /// </code>
-        /// </example>
         /// <param name="documentId"> Path to document to upload,
         /// Same as provided to <see cref="CreateDocument"/></param>
         /// <param name="groundTruth"> A list of ground truth items </param>
+        /// <param name="datasetId"> change or add the documents datasetId </param>
         /// <returns>
         /// A deserialized object that can be interpreted as a Dictionary with the fields
         /// documentId, consentId, uploadUrl, contentType and ground truth.
         /// </returns>
         ///
-        public object UpdateDocument(string documentId, List<Dictionary<string, string>> groundTruth)
-        {
-            var bodyDict = new Dictionary<string, List<Dictionary<string,string>>> {{"groundTruth", groundTruth}};
+        public object UpdateDocument(
+            string documentId,
+            List<Dictionary<string, string>>? groundTruth = null,
+            string? datasetId = null
+        ) {
+            var body = new Dictionary<string, object>();
 
-            // Doing a manual cast from Dictionary to object to help out the serialization process
-            string bodyString = JsonConvert.SerializeObject(bodyDict);
-            object body = JsonConvert.DeserializeObject(bodyString);
+            if (groundTruth != null) {
+                string groundTruthString = JsonConvert.SerializeObject(groundTruth);
+                body.Add("groundTruth", JsonConvert.DeserializeObject(groundTruthString));
+            }
+
+            if (datasetId != null) {
+                body.Add("datasetId", datasetId);
+            }
 
             RestRequest request = ClientRestRequest(Method.PATCH, $"/documents/{documentId}", body);
             return ExecuteRequestResilient(RestSharpClient, request);
@@ -433,8 +431,13 @@ namespace Lucidtech.Las
             string? consentId = null,
             int? maxResults = null,
             string? nextToken = null,
-            string? datasetId = null
+            string? datasetId = null,
+            bool deleteAll = false
         ) {
+            if (maxResults != null && deleteAll) {
+                throw new ArgumentException("Cannot specify maxResults when deleteAll=True");
+            }
+
             var queryParams = new Dictionary<string, object?>();
 
             if (batchId != null) {
@@ -458,6 +461,34 @@ namespace Lucidtech.Las
             }
 
             RestRequest request = ClientRestRequest(Method.DELETE, "/documents", null, queryParams);
+            var objectResponse = ExecuteRequestResilient(RestSharpClient, request);
+            var response = JsonSerialPublisher.ObjectToDict<Dictionary<string, object>>(objectResponse);
+
+            var documentsDeleted = new List<object>();
+            if (deleteAll == true) {
+                documentsDeleted.AddRange(JsonSerialPublisher.ObjectToDict<List<object>>(response["documents"]));
+
+                while (response["nextToken"] != null) {
+                    queryParams["nextToken"] = response["nextToken"].ToString();
+                    request = ClientRestRequest(Method.DELETE, "/documents", null, queryParams);
+                    var intermediateObjectResponse = ExecuteRequestResilient(RestSharpClient, request);
+                    response = JsonSerialPublisher.ObjectToDict<Dictionary<string, object>>(intermediateObjectResponse);
+                    documentsDeleted.AddRange(JsonSerialPublisher.ObjectToDict<List<object>>(response["documents"]));
+                    Console.WriteLine($"Deleted {documentsDeleted.Count} documents so far");
+                }
+
+                response["documents"] = documentsDeleted;
+            }
+
+            string responseString = JsonConvert.SerializeObject(response);
+            return JsonConvert.DeserializeObject(responseString);
+        }
+
+        /// <summary>Delete a document, calls the DELETE /documents/{documentId} endpoint.
+        /// <param name="documentId">Id of the document</param>
+        /// <returns>Document response from REST API</returns>
+        public object DeleteDocument(string documentId) {
+            var request = ClientRestRequest(Method.DELETE, $"/documents/{documentId}");
             return ExecuteRequestResilient(RestSharpClient, request);
         }
 
@@ -525,18 +556,11 @@ namespace Lucidtech.Las
         /// <param name="deleteDocuments">Set to true to delete documents in batch before deleting batch</param>
         /// <returns>Batch response from REST API</returns>
         public object DeleteBatch(string batchId, bool deleteDocuments = false) {
+
             if (deleteDocuments == true) {
-                var objectResponse = this.DeleteDocuments(batchId: batchId);
-                var response = JsonSerialPublisher.ObjectToDict<Dictionary<string, object>>(objectResponse);
-                while (response["nextToken"] != null)
-                {
-                    objectResponse = this.DeleteDocuments(
-                        batchId: batchId,
-                        nextToken: response["nextToken"].ToString()
-                    );
-                    response = JsonSerialPublisher.ObjectToDict<Dictionary<string, object>>(objectResponse);
-                }
+                this.DeleteDocuments(batchId: batchId, deleteAll: true);
             }
+
             var request = ClientRestRequest(Method.DELETE, $"/batches/{batchId}");
             return ExecuteRequestResilient(RestSharpClient, request);
         }
@@ -635,18 +659,11 @@ namespace Lucidtech.Las
         /// <param name="deleteDocuments">Set to true to delete documents in dataset before deleting dataset</param>
         /// <returns>Dataset response from REST API</returns>
         public object DeleteDataset(string datasetId, bool deleteDocuments = false) {
+
             if (deleteDocuments == true) {
-                var objectResponse = this.DeleteDocuments(datasetId: datasetId);
-                var response = JsonSerialPublisher.ObjectToDict<Dictionary<string, object>>(objectResponse);
-                while (response["nextToken"] != null)
-                {
-                    objectResponse = this.DeleteDocuments(
-                        datasetId: datasetId,
-                        nextToken: response["nextToken"].ToString()
-                    );
-                    response = JsonSerialPublisher.ObjectToDict<Dictionary<string, object>>(objectResponse);
-                }
+                this.DeleteDocuments(datasetId: datasetId, deleteAll: true);
             }
+
             var request = ClientRestRequest(Method.DELETE, $"/datasets/{datasetId}");
             return ExecuteRequestResilient(RestSharpClient, request);
         }
@@ -916,6 +933,90 @@ namespace Lucidtech.Las
             return ExecuteRequestResilient(RestSharpClient, request);
         }
 
+        /// <summary>
+        /// Create a data bundle handle, calls the POST /models/{modelId}/dataBundles endpoint.
+        /// </summary>
+        /// <param name="modelId">Id of the model </param>
+        /// <param name="datasetIds">List of Dataset Ids that will be included in the data bundle
+        /// <param name="name">Name of the data bundle</param>
+        /// <param name="description">A brief description of the data bundle </param>
+        /// <returns>Data Bundle response from REST API</returns>
+        public object CreateDataBundle(
+            string modelId,
+            List<string> datasetIds,
+            string? name = null,
+            string? description = null
+        ) {
+            var body = new Dictionary<string, object> {
+                {"datasetIds", datasetIds},
+            };
+
+            if (name != null) {
+                body.Add("name", name);
+            }
+
+            if (description != null) {
+                body.Add("description", description);
+            }
+
+            RestRequest request = ClientRestRequest(Method.POST, $"/models/{modelId}/dataBundles", body);
+            return ExecuteRequestResilient(RestSharpClient, request);
+        }
+
+        /// <summary>List data bundles available, calls the GET /models/{modelId}/dataBundles endpoint.</summary>
+        /// <param name="modelId">Id of the model</param>
+        /// <param name="maxResults">Number of items to show on a single page</param>
+        /// <param name="nextToken">Token to retrieve the next page</param>
+        /// <returns>
+        /// JSON object with two keys:
+        /// - "dataBundles" which contains a list of data bundle objects
+        /// - "nextToken" allowing for retrieving the next portion of data
+        /// </returns>
+        public object ListDataBundles(string modelId, int? maxResults = null, string? nextToken = null) {
+            var queryParams = new Dictionary<string, object?>();
+
+            if (maxResults != null) {
+                queryParams.Add("maxResults", maxResults.ToString());
+            }
+
+            if (nextToken != null) {
+                queryParams.Add("nextToken", nextToken);
+            }
+
+            RestRequest request = ClientRestRequest(Method.GET, $"/models/{modelId}/dataBundles", null, queryParams);
+            return ExecuteRequestResilient(RestSharpClient, request);
+        }
+
+        /// <summary>Updates an existing data bundle, calls the PATCH /models/{modelId}/dataBundles/{dataBundleId} endpoint.</summary>
+        /// <param name="modelId">Id of the model</param>
+        /// <param name="dataBundleId">Id of the data bundle</param>
+        /// <param name="attributes">Additional attributes</param>
+        /// <returns>Data Bundle response from REST API</returns>
+        public object UpdateDataBundle(
+            string modelId,
+            string dataBundleId,
+            Dictionary<string, string?>? attributes
+        ) {
+            var body = new Dictionary<string, object?>();
+
+            if (attributes != null) {
+                foreach (KeyValuePair<string, string?> entry in attributes) {
+                    body.Add(entry.Key, entry.Value);
+                }
+            }
+            string url = $"/models/{modelId}/dataBundles/{dataBundleId}";
+            RestRequest request = ClientRestRequest(Method.PATCH, url, body);
+            return ExecuteRequestResilient(RestSharpClient, request);
+        }
+
+        /// <summary>Delete a data bundle, calls the DELETE /models/{modelId}/dataBundles/{dataBundleId} endpoint.
+        /// <param name="modelId">Id of the model</param>
+        /// <param name="dataBundleId">Id of the data bundle</param>
+        /// <returns>Data Bundle response from REST API</returns>
+        public object DeleteDataBundle(string modelId, string dataBundleId) {
+            var request = ClientRestRequest(Method.DELETE, $"/models/{modelId}/dataBundles/{dataBundleId}");
+            return ExecuteRequestResilient(RestSharpClient, request);
+        }
 
         /// <summary>Creates an secret, calls the POST /secrets endpoint.</summary>
         /// <example>

--- a/Lucidtech/Las/Client.cs
+++ b/Lucidtech/Las/Client.cs
@@ -464,9 +464,8 @@ namespace Lucidtech.Las
             var objectResponse = ExecuteRequestResilient(RestSharpClient, request);
             var response = JsonSerialPublisher.ObjectToDict<Dictionary<string, object>>(objectResponse);
 
-            var documentsDeleted = new List<object>();
-            if (deleteAll == true) {
-                documentsDeleted.AddRange(JsonSerialPublisher.ObjectToDict<List<object>>(response["documents"]));
+            if (deleteAll) {
+                var documentsDeleted = JsonSerialPublisher.ObjectToDict<List<object>>(response["documents"]);
 
                 while (response["nextToken"] != null) {
                     queryParams["nextToken"] = response["nextToken"].ToString();
@@ -557,7 +556,7 @@ namespace Lucidtech.Las
         /// <returns>Batch response from REST API</returns>
         public object DeleteBatch(string batchId, bool deleteDocuments = false) {
 
-            if (deleteDocuments == true) {
+            if (deleteDocuments) {
                 this.DeleteDocuments(batchId: batchId, deleteAll: true);
             }
 
@@ -660,7 +659,7 @@ namespace Lucidtech.Las
         /// <returns>Dataset response from REST API</returns>
         public object DeleteDataset(string datasetId, bool deleteDocuments = false) {
 
-            if (deleteDocuments == true) {
+            if (deleteDocuments) {
                 this.DeleteDocuments(datasetId: datasetId, deleteAll: true);
             }
 

--- a/Lucidtech/Lucidtech.csproj
+++ b/Lucidtech/Lucidtech.csproj
@@ -15,7 +15,7 @@
     <TargetFrameworks>netstandard20</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageId>Lucidtech.Las</PackageId>
-    <PackageVersion>1.4.1</PackageVersion>
+    <PackageVersion>1.5.0</PackageVersion>
     <Title>Lucidtech AI Services</Title>
     <Authors>Lucidtech AS</Authors>
     <Description>SDK for accessing Lucidtech AI Services</Description>

--- a/Test/Service.cs
+++ b/Test/Service.cs
@@ -28,7 +28,7 @@ namespace Test.Service
                 case "batches":
                     return new[] {"batches", "nextToken"};
                 case "dataset":
-                    return new[] {"name", "description", "datasetId", "version", "numberOfDocuments"};
+                    return new[] {"name", "description", "datasetId", "version"};
                 case "datasets":
                     return new[] {"datasets", "nextToken"};
                 case "document":
@@ -41,6 +41,10 @@ namespace Test.Service
                     return new[] {"modelId", "name", "description", "height", "width", "preprocessConfig", "fieldConfig", "status", "createdTime", "updatedTime"};
                 case "models":
                     return new[] {"models", "nextToken"};
+                case "dataBundle":
+                    return new[] {"modelId", "dataBundleId", "description", "status", "createdTime", "updatedTime"};
+                case "dataBundles":
+                    return new[] {"dataBundles", "nextToken"};
                 case "prediction":
                     return new [] {"documentId", "predictions"};
                 case "predictions":

--- a/Test/Service.cs
+++ b/Test/Service.cs
@@ -28,7 +28,7 @@ namespace Test.Service
                 case "batches":
                     return new[] {"batches", "nextToken"};
                 case "dataset":
-                    return new[] {"name", "description", "datasetId", "version"};
+                    return new[] {"name", "description", "datasetId", "version", "numberOfDocuments"};
                 case "datasets":
                     return new[] {"datasets", "nextToken"};
                 case "document":

--- a/Test/Test.cs
+++ b/Test/Test.cs
@@ -61,9 +61,9 @@ namespace Test
                 new Dictionary<string, string>{{"label", "purchase_date"},{"value", "2007-07-30"}}
             };
             var response = Toby.CreateDocument(
-                body,
-                Example.ContentType(),
-                Example.ConsentId(),
+                content: body,
+                contentType: Example.ContentType(),
+                consentId: Example.ConsentId(),
                 groundTruth: groundTruth
             );
             CreateDocResponse = JsonSerialPublisher.ObjectToDict<Dictionary<string, object>>(response);
@@ -233,7 +233,11 @@ namespace Test
                 new Dictionary<string, string>{{"label", "total_amount"},{"value", total_amount}},
                 new Dictionary<string, string>{{"label", "purchase_date"},{"value", purchase_date}}
             };
-            var response = Toby.UpdateDocument((string)CreateDocResponse["documentId"], ground_truth);
+            var response = Toby.UpdateDocument(
+                (string)CreateDocResponse["documentId"],
+                ground_truth
+                //Util.ResourceId("dataset")
+            );
             CheckKeys(Util.ExpectedKeys("document"), response);
         }
 
@@ -248,6 +252,12 @@ namespace Test
                 datasetId: Util.ResourceId("dataset")
             );
             CheckKeys(Util.ExpectedKeys("documents"), response);
+        }
+
+        [Ignore("delete endpoints doesn't work")]
+        public void TestDeleteDocument() {
+            var response = Toby.DeleteDocument(Util.ResourceId("batch"), deleteDocuments);
+            CheckKeys(Util.ExpectedKeys("document"), response);
         }
 
         [TestCase(null, null)]
@@ -391,6 +401,54 @@ namespace Test
         public void TestUpdateModelSimple() {
             var response = Toby.UpdateModel(modelId: Util.ResourceId("model"), width: 501);
             CheckKeys(Util.ExpectedKeys("model"), response);
+        }
+
+        [TestCase(null, null)]
+        [TestCase("name", "description")]
+        public void TestCreateDataBundle(string? name, string? description)
+        {
+            var datasetIds= new List<string>{ Util.ResourceId("dataset"), Util.ResourceId("dataset")};
+            var response = Toby.CreateDataBundle(
+                modelId: Util.ResourceId("model"),
+                datasetIds: datasetIds,
+                name: name,
+                description: description
+            );
+            CheckKeys(Util.ExpectedKeys("dataBundle"), response);
+        }
+
+        [Test]
+        public void TestListDataBundles() {
+            var response = Toby.ListDataBundles(
+                modelId: Util.ResourceId("model"),
+                maxResults: 100,
+                nextToken: "foo"
+            );
+            CheckKeys(Util.ExpectedKeys("dataBundles"), response);
+        }
+
+        [TestCase("name", "description")]
+        [TestCase("", null)]
+        [TestCase(null, null)]
+        public void TestUpdateDataBundle(string? name, string? description) {
+            var parameters = new Dictionary<string, string?> {
+                {"name", name},
+                {"description", description}
+            };
+            var response = Toby.UpdateDataBundle(
+                modelId: Util.ResourceId("model"),
+                dataBundleId: Util.ResourceId("model-data-bundle"),
+                attributes: parameters
+            );
+            CheckKeys(Util.ExpectedKeys("dataBundle"), response);
+        }
+
+        [Ignore("delete endpoints doesn't work")]
+        [TestCase(true)]
+        [TestCase(false)]
+        public void TestDeleteDataBundle(bool deleteDocuments) {
+            var response = Toby.DeleteDataBundle(Util.ResourceId("model"), Util.ResourceId("model-data-bundle"));
+            CheckKeys(Util.ExpectedKeys("dataBundle"), response);
         }
 
         [TestCase("foo", 3)]

--- a/Test/Test.cs
+++ b/Test/Test.cs
@@ -61,9 +61,9 @@ namespace Test
                 new Dictionary<string, string>{{"label", "purchase_date"},{"value", "2007-07-30"}}
             };
             var response = Toby.CreateDocument(
-                content: body,
-                contentType: Example.ContentType(),
-                consentId: Example.ConsentId(),
+                body,
+                Example.ContentType(),
+                Example.ConsentId(),
                 groundTruth: groundTruth
             );
             CreateDocResponse = JsonSerialPublisher.ObjectToDict<Dictionary<string, object>>(response);
@@ -235,8 +235,8 @@ namespace Test
             };
             var response = Toby.UpdateDocument(
                 (string)CreateDocResponse["documentId"],
-                ground_truth
-                //Util.ResourceId("dataset")
+                ground_truth,
+                Util.ResourceId("dataset")
             );
             CheckKeys(Util.ExpectedKeys("document"), response);
         }

--- a/Test/Test.cs
+++ b/Test/Test.cs
@@ -256,7 +256,7 @@ namespace Test
 
         [Ignore("delete endpoints doesn't work")]
         public void TestDeleteDocument() {
-            var response = Toby.DeleteDocument(Util.ResourceId("batch"), deleteDocuments);
+            var response = Toby.DeleteDocument(Util.ResourceId("document"));
             CheckKeys(Util.ExpectedKeys("document"), response);
         }
 


### PR DESCRIPTION
- add data bundle endpoints
- Finish all endpoints for data bundles
- add datasetId as optional parameter to UpdateDocument
- add deleteAll for documents
- fixes after testing on real API
- temporary fixes
- use deleteAll flag when deleting documents from DeleteDataset and DeleteBatch
- add delete documents
- update version
